### PR TITLE
ci(release-please): add permissions block so token can create PRs

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -4,6 +4,11 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: write
+  pull-requests: write
+  packages: write
+
 jobs:
   release-please:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
Release-please has been failing on main with \`Resource not accessible by integration\` because the repo's \`default_workflow_permissions\` is set to \`read\` and this workflow didn't override that with its own \`permissions:\` block. Sibling repo ZeroAlloc.Resilience has the block and release-please works there.

## Why this blocks the icon release
The icon PR #2 merged cleanly but release-please couldn't cut 0.0.2 because of this. Once this merges, the next \`fix:\` commit (this one counts) will trigger release-please successfully and publish the icon to NuGet.

## Test Plan
- [ ] release-please workflow succeeds on main after merge
- [ ] release-please opens a release PR for 0.0.2
- [ ] merging that PR publishes all 8 Scheduling packages to NuGet with the Z icon

🤖 Generated with [Claude Code](https://claude.com/claude-code)