### PR TITLE
feat(scheduling): use ConcurrentHeapSpanDictionary for InMemoryJobStore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ obj/
 .tmp/
 
 BenchmarkDotNet.Artifacts/
+.worktrees/

--- a/src/ZeroAlloc.Scheduling.InMemory/InMemoryJobStore.cs
+++ b/src/ZeroAlloc.Scheduling.InMemory/InMemoryJobStore.cs
@@ -1,14 +1,14 @@
-using System.Collections.Concurrent;
+using ZeroAlloc.Collections;
 
 namespace ZeroAlloc.Scheduling.InMemory;
 
 /// <summary>Thread-safe in-memory job store. Use in tests — not for production.</summary>
-public sealed class InMemoryJobStore : IJobStore, IJobDashboardStore
+public sealed class InMemoryJobStore : IJobStore, IJobDashboardStore, IDisposable
 {
-    private readonly ConcurrentDictionary<Guid, JobEntry> _entries = new();
+    private readonly ConcurrentHeapSpanDictionary<Guid, JobEntry> _entries = new();
 
     /// <summary>All entries — for test assertions.</summary>
-    public IReadOnlyCollection<JobEntry> AllEntries => _entries.Values.ToList();
+    public IReadOnlyCollection<JobEntry> AllEntries => _entries.ToValuesArray();
 
     public ValueTask EnqueueAsync(
         string typeName, byte[] payload, DateTimeOffset scheduledAt,
@@ -150,7 +150,7 @@ public sealed class InMemoryJobStore : IJobStore, IJobDashboardStore
         string typeName, byte[] payload, DateTimeOffset scheduledAt,
         string? cronExpression, int maxAttempts, CancellationToken ct)
     {
-        bool exists = _entries.Values.Any(e =>
+        bool exists = _entries.ToValuesArray().Any(e =>
             string.Equals(e.TypeName, typeName, StringComparison.Ordinal) &&
             (e.Status == JobStatus.Pending || e.Status == JobStatus.Running));
 
@@ -177,7 +177,7 @@ public sealed class InMemoryJobStore : IJobStore, IJobDashboardStore
 
     public Task<JobSummary> GetSummaryAsync(CancellationToken ct = default)
     {
-        var counts = _entries.Values
+        var counts = _entries.ToValuesArray()
             .GroupBy(e => e.Status)
             .ToDictionary(g => g.Key, g => g.Count());
         return Task.FromResult(new JobSummary(
@@ -190,7 +190,7 @@ public sealed class InMemoryJobStore : IJobStore, IJobDashboardStore
 
     public Task<IReadOnlyList<JobEntry>> QueryByStatusAsync(
         JobStatus[] statuses, int page = 1, int pageSize = 50, CancellationToken ct = default)
-        => Task.FromResult<IReadOnlyList<JobEntry>>(_entries.Values
+        => Task.FromResult<IReadOnlyList<JobEntry>>(_entries.ToValuesArray()
             .Where(e => statuses.Contains(e.Status))
             .OrderByDescending(e => e.ScheduledAt)
             .Skip((page - 1) * pageSize)
@@ -198,7 +198,7 @@ public sealed class InMemoryJobStore : IJobStore, IJobDashboardStore
             .ToList());
 
     public Task<IReadOnlyList<JobEntry>> GetRecurringAsync(CancellationToken ct = default)
-        => Task.FromResult<IReadOnlyList<JobEntry>>(_entries.Values
+        => Task.FromResult<IReadOnlyList<JobEntry>>(_entries.ToValuesArray()
             .Where(e => e.CronExpression != null && e.Status == JobStatus.Pending)
             .ToList());
 
@@ -226,4 +226,7 @@ public sealed class InMemoryJobStore : IJobStore, IJobDashboardStore
         _entries.TryRemove(id, out _);
         return Task.CompletedTask;
     }
+
+    /// <summary>Returns the pooled bucket array. Tests typically rely on GC; production callers should dispose explicitly.</summary>
+    public void Dispose() => _entries.Dispose();
 }

--- a/src/ZeroAlloc.Scheduling.InMemory/ZeroAlloc.Scheduling.InMemory.csproj
+++ b/src/ZeroAlloc.Scheduling.InMemory/ZeroAlloc.Scheduling.InMemory.csproj
@@ -8,5 +8,6 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ZeroAlloc.Scheduling\ZeroAlloc.Scheduling.csproj" />
+    <PackageReference Include="ZeroAlloc.Collections" Version="0.1.6" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Closes #14.

## Summary

Replaces `System.Collections.Concurrent.ConcurrentDictionary<Guid, JobEntry>` in `InMemoryJobStore` with `ZeroAlloc.Collections.ConcurrentHeapSpanDictionary<Guid, JobEntry>` (shipped in [v0.1.6](https://www.nuget.org/packages/ZeroAlloc.Collections/0.1.6)) — fulfils the [ecosystem matrix](https://github.com/ZeroAlloc-Net/ZeroAlloc.github/blob/main/docs/INTEGRATION-MATRIX.md) row 34.

## Changes

- `src/ZeroAlloc.Scheduling.InMemory/ZeroAlloc.Scheduling.InMemory.csproj` — add `<PackageReference Include="ZeroAlloc.Collections" Version="0.1.6" />`.
- `src/ZeroAlloc.Scheduling.InMemory/InMemoryJobStore.cs`
  - Field type → `ConcurrentHeapSpanDictionary<Guid, JobEntry>`
  - Class now `IDisposable`; `Dispose()` returns the pooled bucket array
  - Three `.Values` call sites → `.ToValuesArray()` (LINQ-compatible snapshot)
  - Indexer / `TryUpdate` / `TryGetValue` / `TryRemove` / `foreach` drop in unchanged — API is `ConcurrentDictionary`-shaped.

## Honest note on the benchmark AC

The issue's acceptance criterion mentions a Gen0 reduction on the write path. For a long-lived singleton store, the bucket-array allocation is one-time — the measurable Gen0 improvement is marginal. The concrete wins are (a) disposal cleanup returning buckets to `ArrayPool` rather than GC, and (b) ecosystem cohesion (the suite now dogfoods its own concurrent primitive). Happy to add a formal benchmark if the matrix row needs one before closure.

## Test plan

- [x] `dotnet test ZeroAlloc.Scheduling.slnx -c Release` — 48/48 green (28 core + 5 EfCore + 9 Dashboard + 6 Generator).
- [ ] CI `build` + `aot-smoke` + `lint-commits`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)