### PR TITLE
feat: add ZeroAlloc.Scheduling.Resilience bridge package (Scheduling#18)

### DIFF
--- a/ZeroAlloc.Scheduling.slnx
+++ b/ZeroAlloc.Scheduling.slnx
@@ -7,10 +7,12 @@
   <Project Path="src/ZeroAlloc.Scheduling.Dashboard/ZeroAlloc.Scheduling.Dashboard.csproj" />
   <Project Path="src/ZeroAlloc.Scheduling.Dashboard.Blazor/ZeroAlloc.Scheduling.Dashboard.Blazor.csproj" />
   <Project Path="src/ZeroAlloc.Scheduling.Mediator/ZeroAlloc.Scheduling.Mediator.csproj" />
+  <Project Path="src/ZeroAlloc.Scheduling.Resilience/ZeroAlloc.Scheduling.Resilience.csproj" />
   <Project Path="benchmarks/ZeroAlloc.Scheduling.Benchmarks/ZeroAlloc.Scheduling.Benchmarks.csproj" />
   <Project Path="samples/ZeroAlloc.Scheduling.AotSmoke/ZeroAlloc.Scheduling.AotSmoke.csproj" />
   <Project Path="tests/ZeroAlloc.Scheduling.Tests/ZeroAlloc.Scheduling.Tests.csproj" />
   <Project Path="tests/ZeroAlloc.Scheduling.Generator.Tests/ZeroAlloc.Scheduling.Generator.Tests.csproj" />
   <Project Path="tests/ZeroAlloc.Scheduling.EfCore.Tests/ZeroAlloc.Scheduling.EfCore.Tests.csproj" />
   <Project Path="tests/ZeroAlloc.Scheduling.Dashboard.Tests/ZeroAlloc.Scheduling.Dashboard.Tests.csproj" />
+  <Project Path="tests/ZeroAlloc.Scheduling.Resilience.Tests/ZeroAlloc.Scheduling.Resilience.Tests.csproj" />
 </Solution>

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,8 +19,9 @@ Source-generated background job scheduler for .NET 8 and .NET 10.
 | 3 | [Backends](stores.md) | InMemory, EF Core, and Redis store configuration |
 | 4 | [Dashboard](dashboard.md) | Embedded HTML dashboard and Blazor component |
 | 5 | [Mediator Bridge](mediator-bridge.md) | Route job execution through ZeroAlloc.Mediator |
-| 6 | [Diagnostics](diagnostics.md) | ZASCH001 compiler warning reference |
-| 7 | [Performance](performance.md) | Throughput, allocation profile, and tuning guide |
+| 6 | [Resilience Bridge](resilience-bridge.md) | Wrap executors in retry, circuit-breaker, and timeout policies |
+| 7 | [Diagnostics](diagnostics.md) | ZASCH001 compiler warning reference |
+| 8 | [Performance](performance.md) | Throughput, allocation profile, and tuning guide |
 
 ## Quick Reference
 

--- a/docs/resilience-bridge.md
+++ b/docs/resilience-bridge.md
@@ -1,0 +1,84 @@
+---
+id: resilience-bridge
+title: Resilience Bridge
+slug: /docs/resilience-bridge
+description: Wrap IJobTypeExecutor implementations in a ZeroAlloc.Resilience-generated proxy to add retry, circuit-breaker, and timeout policies.
+sidebar_position: 6
+---
+
+# Resilience Bridge
+
+The `ZeroAlloc.Scheduling.Resilience` package wraps any `IJobTypeExecutor` implementation in a `ZeroAlloc.Resilience`-generated proxy. This lets you add retry, circuit-breaker, timeout, or bulkhead policies to job execution without changing executor code.
+
+## Installation
+
+```bash
+dotnet add package ZeroAlloc.Scheduling
+dotnet add package ZeroAlloc.Scheduling.Resilience
+dotnet add package ZeroAlloc.Resilience
+dotnet add package ZeroAlloc.Resilience.Generator
+```
+
+## Define the Resilience Interface
+
+Declare an interface that extends `IJobTypeExecutor` and annotates `ExecuteAsync` with resilience attributes:
+
+```csharp
+using ZeroAlloc.Scheduling;
+using ZeroAlloc.Resilience;
+
+[Retry(MaxAttempts = 3, DelayMs = 500, BackoffType = BackoffType.Exponential)]
+[CircuitBreaker(FailureThreshold = 5, SamplingDurationMs = 30_000, BreakDurationMs = 10_000)]
+public interface IResilientSendReportExecutor : IJobTypeExecutor
+{
+}
+```
+
+The `ZeroAlloc.Resilience` generator emits a `ResilientSendReportExecutorProxy` class that implements this interface and wraps your real executor.
+
+## Register
+
+```csharp
+// Register your real executor (generated or custom)
+services.AddTransient<SendReportJobTypeExecutor>();
+
+// AddSchedulingResilience wires the proxy as IJobTypeExecutor
+services.AddSchedulingResilience<
+    IResilientSendReportExecutor,
+    ResilientSendReportExecutorProxy>();
+
+// Standard scheduling setup
+services.AddScheduling()
+        .AddSchedulingInMemory()
+        .AddSendReportJob();
+```
+
+`AddSchedulingResilience<TExecutorInterface, TResilienceProxy>()` registers `TResilienceProxy` as `Transient` and binds it as `IJobTypeExecutor`.
+
+## Type Parameters
+
+| Parameter | Description |
+|-----------|-------------|
+| `TExecutorInterface` | Your resilience interface (extends `IJobTypeExecutor`) |
+| `TResilienceProxy` | The generated proxy class (implements `TExecutorInterface`) |
+
+## How It Works
+
+The resilience proxy is generated at compile time by `ZeroAlloc.Resilience.Generator`. On every `ExecuteAsync` call, the proxy applies the declared policies before forwarding to the inner executor. The scheduling worker never knows a proxy is involved — it resolves `IJobTypeExecutor` from DI and calls `ExecuteAsync` as normal.
+
+## Combining Policies
+
+Multiple attributes are combined in declaration order — the first listed policy is outermost:
+
+```csharp
+[Timeout(TimeoutMs = 10_000)]
+[Retry(MaxAttempts = 3, DelayMs = 200)]
+[CircuitBreaker(FailureThreshold = 5, SamplingDurationMs = 60_000, BreakDurationMs = 15_000)]
+public interface IResilientSendReportExecutor : IJobTypeExecutor { }
+```
+
+Here, timeout wraps retry, which wraps the circuit breaker — so each attempt is independently time-boxed.
+
+## Interaction with Built-in Retry
+
+The scheduling worker has its own retry mechanism controlled by `[Job(MaxAttempts = N)]` and `SchedulingOptions.DefaultMaxAttempts`. When using the resilience bridge, the proxy retries are transparent to the worker — the worker only sees a failure if all proxy retry attempts are exhausted. Consider setting `MaxAttempts = 1` on the job or relying entirely on the resilience proxy's retry logic to avoid double-retrying.

--- a/src/ZeroAlloc.Scheduling.Resilience/SchedulingResilienceServiceCollectionExtensions.cs
+++ b/src/ZeroAlloc.Scheduling.Resilience/SchedulingResilienceServiceCollectionExtensions.cs
@@ -1,0 +1,47 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace ZeroAlloc.Scheduling.Resilience;
+
+public static class SchedulingResilienceServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers a Resilience-generated proxy <typeparamref name="TResilienceProxy"/> as the
+    /// <see cref="IJobTypeExecutor"/> for a specific job type.
+    /// </summary>
+    /// <typeparam name="TExecutorInterface">
+    /// A custom executor interface that extends <see cref="IJobTypeExecutor"/> and carries
+    /// Resilience attributes (<c>[Retry]</c>, <c>[CircuitBreaker]</c>, etc.). The Resilience
+    /// source generator emits the proxy from this interface.
+    /// </typeparam>
+    /// <typeparam name="TResilienceProxy">
+    /// The source-generated Resilience proxy class for <typeparamref name="TExecutorInterface"/>.
+    /// </typeparam>
+    /// <remarks>
+    /// Define your executor interface with Resilience attributes, implement it, then wire everything:
+    /// <code>
+    /// // 1. Define an interface with Resilience attributes:
+    /// [Retry(MaxAttempts = 5, BackoffMs = 500)]
+    /// [CircuitBreaker(FailureThreshold = 3, DurationMs = 30_000)]
+    /// public interface ISendEmailJobExecutor : IJobTypeExecutor { }
+    ///
+    /// // 2. Implement it:
+    /// public sealed class SendEmailJobExecutor : ISendEmailJobExecutor { ... }
+    ///
+    /// // 3. Register in DI (the Resilience generator emits ISendEmailJobExecutorResilienceProxy):
+    /// services
+    ///     .AddScheduling()
+    ///     .AddSchedulingResilience&lt;ISendEmailJobExecutor, ISendEmailJobExecutorResilienceProxy&gt;();
+    /// </code>
+    /// The proxy wraps the inner <typeparamref name="TExecutorInterface"/> implementation and
+    /// is resolved as <see cref="IJobTypeExecutor"/> by the scheduling worker.
+    /// </remarks>
+    public static IServiceCollection AddSchedulingResilience<TExecutorInterface, TResilienceProxy>(
+        this IServiceCollection services)
+        where TExecutorInterface : class, IJobTypeExecutor
+        where TResilienceProxy : class, TExecutorInterface
+    {
+        services.AddTransient<TResilienceProxy>();
+        services.AddTransient<IJobTypeExecutor>(sp => sp.GetRequiredService<TResilienceProxy>());
+        return services;
+    }
+}

--- a/src/ZeroAlloc.Scheduling.Resilience/ZeroAlloc.Scheduling.Resilience.csproj
+++ b/src/ZeroAlloc.Scheduling.Resilience/ZeroAlloc.Scheduling.Resilience.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+    <PackageId>ZeroAlloc.Scheduling.Resilience</PackageId>
+    <Description>ZeroAlloc.Resilience bridge for ZeroAlloc.Scheduling — wraps IJobTypeExecutor implementations in a Resilience-generated proxy.</Description>
+    <Version>0.0.0-local</Version>
+    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="ZeroAlloc.Resilience" Version="1.0.0" />
+    <!-- Pinned to 10.0.0 to match ZeroAlloc.Scheduling's transitive minimum (Scheduling#15) -->
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
+    <ProjectReference Include="..\ZeroAlloc.Scheduling\ZeroAlloc.Scheduling.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/ZeroAlloc.Scheduling.Resilience.Tests/SchedulingResilienceExtensionsTests.cs
+++ b/tests/ZeroAlloc.Scheduling.Resilience.Tests/SchedulingResilienceExtensionsTests.cs
@@ -1,0 +1,81 @@
+using Microsoft.Extensions.DependencyInjection;
+using ZeroAlloc.Scheduling;
+using ZeroAlloc.Scheduling.Resilience;
+
+namespace ZeroAlloc.Scheduling.Resilience.Tests;
+
+/// <summary>
+/// Validates that AddSchedulingResilience wires a proxy as IJobTypeExecutor.
+/// Uses a hand-written proxy to represent what the Resilience generator would emit.
+/// </summary>
+public class SchedulingResilienceExtensionsTests
+{
+    [Fact]
+    public void AddSchedulingResilience_RegistersProxyAsExecutor()
+    {
+        var services = new ServiceCollection();
+        services.AddTransient<SendEmailJobExecutorImpl>();
+        services.AddSchedulingResilience<ISendEmailJobExecutor, SendEmailJobExecutorProxy>();
+
+        var provider = services.BuildServiceProvider();
+        var executor = provider.GetRequiredService<IJobTypeExecutor>();
+
+        executor.Should().BeOfType<SendEmailJobExecutorProxy>();
+    }
+
+    [Fact]
+    public async Task AddSchedulingResilience_ProxyDelegatesToInnerExecutor()
+    {
+        var services = new ServiceCollection();
+        services.AddTransient<SendEmailJobExecutorImpl>();
+        services.AddSchedulingResilience<ISendEmailJobExecutor, SendEmailJobExecutorProxy>();
+
+        var provider = services.BuildServiceProvider();
+        var executor = provider.GetRequiredService<IJobTypeExecutor>();
+        var proxy = (SendEmailJobExecutorProxy)executor;
+
+        var payload = System.Text.Encoding.UTF8.GetBytes("{}");
+        var ctx = new JobContext
+        {
+            JobId = new JobId(Guid.NewGuid()),
+            Attempt = 1,
+            ScheduledAt = DateTimeOffset.UtcNow,
+            Services = new ServiceCollection().BuildServiceProvider(),
+        };
+
+        await executor.ExecuteAsync(payload, ctx, CancellationToken.None);
+
+        proxy.Inner.CallCount.Should().Be(1);
+    }
+
+    // ---- Supporting types ----
+
+    private interface ISendEmailJobExecutor : IJobTypeExecutor { }
+
+    private sealed class SendEmailJobExecutorImpl : ISendEmailJobExecutor
+    {
+        public int CallCount { get; private set; }
+        public string TypeName => "SendEmail";
+        public int MaxAttempts => 0;
+
+        public ValueTask ExecuteAsync(byte[] payload, JobContext ctx, CancellationToken ct)
+        {
+            CallCount++;
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    // Simulates what the Resilience source generator would emit for ISendEmailJobExecutor.
+    private sealed class SendEmailJobExecutorProxy : ISendEmailJobExecutor
+    {
+        public SendEmailJobExecutorImpl Inner { get; }
+
+        public SendEmailJobExecutorProxy(SendEmailJobExecutorImpl inner) => Inner = inner;
+
+        public string TypeName => Inner.TypeName;
+        public int MaxAttempts => Inner.MaxAttempts;
+
+        public ValueTask ExecuteAsync(byte[] payload, JobContext ctx, CancellationToken ct)
+            => Inner.ExecuteAsync(payload, ctx, ct);
+    }
+}

--- a/tests/ZeroAlloc.Scheduling.Resilience.Tests/ZeroAlloc.Scheduling.Resilience.Tests.csproj
+++ b/tests/ZeroAlloc.Scheduling.Resilience.Tests/ZeroAlloc.Scheduling.Resilience.Tests.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" PrivateAssets="all" />
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
+    <ProjectReference Include="..\..\src\ZeroAlloc.Scheduling.Resilience\ZeroAlloc.Scheduling.Resilience.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <Using Include="FluentAssertions" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary

- New `ZeroAlloc.Scheduling.Resilience` package
- `AddSchedulingResilience<TExecutorInterface, TResilienceProxy>()` wires a Resilience-generated proxy as `IJobTypeExecutor`, allowing users to annotate custom executor interfaces with `[Retry]`, `[CircuitBreaker]`, etc.
- Follows the same pattern as `ZeroAlloc.Outbox.Resilience` and `ZeroAlloc.Rest.Resilience`

## Test plan

- [x] All 53 tests pass (`dotnet test` across all projects)
- [x] `AddSchedulingResilience` registers proxy as `IJobTypeExecutor`
- [x] Proxy delegates `ExecuteAsync` to inner implementation

🤖 Generated with [Claude Code](https://claude.com/claude-code)