### PR TITLE
feat(scheduling)!: migrate DI registration to ISchedulingBuilder fluent API

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ public sealed class CleanupExpiredSessionsJob : IJob
 
 // 2. Register — generated AddCleanupExpiredSessionsJob() wires executor + recurring startup
 services.AddScheduling()
-        .AddSchedulingInMemory()
+        .WithInMemoryStore()
         .AddCleanupExpiredSessionsJob();
 
 // 3. Enqueue a one-off job from application code

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -10,6 +10,20 @@ sidebar_position: 1
 
 ZeroAlloc.Scheduling is a background job scheduler for .NET 8 and .NET 10. You decorate a class with `[Job]`, and the Roslyn source generator emits the executor, DI registration, and optional recurring startup for you at build time — no reflection, no convention scanning, no `IServiceCollection.Scan`.
 
+## Migrating from v1.x
+
+| v1.x | v2.x |
+|---|---|
+| `services.AddScheduling()` returning `IServiceCollection` | `services.AddScheduling()` returning `ISchedulingBuilder` (use `.Services` to recover) |
+| `services.AddSchedulingInMemory()` | `services.AddScheduling().WithInMemoryStore()` |
+| `services.AddSchedulingEfCore(...)` | `services.AddScheduling().WithEfCore(...)` |
+| `services.AddSchedulingOutboxWriter<TJob>()` | `services.AddScheduling().WithOutboxWriter<TJob>()` |
+| `services.AddSchedulingMediator()` | `services.AddScheduling().WithMediator()` |
+| `services.AddSchedulingResilience<TInterface, TProxy>()` | `services.AddScheduling().WithResilience<TInterface, TProxy>()` |
+| `services.AddXxxJob()` (per-job, generator-emitted) | `services.AddScheduling().AddXxxJob()` |
+
+The v1.x extensions remain as `[Obsolete]` shims (diagnostic IDs `ZASCH001`–`ZASCH010`) for one minor version, then are removed.
+
 ## Installation
 
 ```bash
@@ -54,7 +68,7 @@ The generator emits `AddSendWelcomeEmailJob()`. Call it alongside `AddScheduling
 ```csharp
 builder.Services
     .AddScheduling()
-    .AddSchedulingInMemory()
+    .WithInMemoryStore()
     .AddSendWelcomeEmailJob();
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -32,7 +32,7 @@ public sealed class SendWelcomeEmailJob : IJob
 {
     public async ValueTask ExecuteAsync(JobContext ctx, CancellationToken ct) { ... }
 }
-services.AddScheduling().AddSchedulingInMemory().AddSendWelcomeEmailJob();
+services.AddScheduling().WithInMemoryStore().AddSendWelcomeEmailJob();
 await scheduler.EnqueueAsync(new SendWelcomeEmailJob { To = "user@example.com" }, ct);
 
 // Recurring job (every hour)

--- a/docs/mediator-bridge.md
+++ b/docs/mediator-bridge.md
@@ -52,8 +52,8 @@ Register — the generator detects `IRequest<Unit>` and emits a mediator-aware `
 
 ```csharp
 services.AddScheduling()
-        .AddSchedulingInMemory()
-        .AddSchedulingMediator()      // no-op, retained for source compatibility
+        .WithInMemoryStore()
+        .WithMediator()               // no-op, retained for source compatibility
         .AddGenerateInvoicesJob();    // registers MediatorJobTypeExecutor<T>
 ```
 

--- a/docs/resilience-bridge.md
+++ b/docs/resilience-bridge.md
@@ -42,18 +42,16 @@ The `ZeroAlloc.Resilience` generator emits a `ResilientSendReportExecutorProxy` 
 // Register your real executor (generated or custom)
 services.AddTransient<SendReportJobTypeExecutor>();
 
-// AddSchedulingResilience wires the proxy as IJobTypeExecutor
-services.AddSchedulingResilience<
-    IResilientSendReportExecutor,
-    ResilientSendReportExecutorProxy>();
-
-// Standard scheduling setup
+// WithResilience wires the proxy as IJobTypeExecutor
 services.AddScheduling()
-        .AddSchedulingInMemory()
+        .WithInMemoryStore()
+        .WithResilience<
+            IResilientSendReportExecutor,
+            ResilientSendReportExecutorProxy>()
         .AddSendReportJob();
 ```
 
-`AddSchedulingResilience<TExecutorInterface, TResilienceProxy>()` registers `TResilienceProxy` as `Transient` and binds it as `IJobTypeExecutor`.
+`WithResilience<TExecutorInterface, TResilienceProxy>()` registers `TResilienceProxy` as `Transient` and binds it as `IJobTypeExecutor`.
 
 ## Type Parameters
 

--- a/docs/source-generator.md
+++ b/docs/source-generator.md
@@ -100,13 +100,13 @@ internal sealed class SendInvoiceJobJobTypeExecutor : IJobTypeExecutor
     }
 }
 
-// 2. DI extension — call this in your AddXxx registration chain
-public static partial class SchedulingServiceCollectionExtensions
+// 2. DI extension — call this on the ISchedulingBuilder returned by AddScheduling()
+public static partial class SchedulingBuilderExtensions
 {
-    public static IServiceCollection AddSendInvoiceJob(this IServiceCollection services)
+    public static ISchedulingBuilder AddSendInvoiceJob(this ISchedulingBuilder builder)
     {
-        services.AddTransient<IJobTypeExecutor, SendInvoiceJobJobTypeExecutor>();
-        return services;
+        builder.Services.AddTransient<IJobTypeExecutor, SendInvoiceJobJobTypeExecutor>();
+        return builder;
     }
 }
 ```

--- a/docs/stores.md
+++ b/docs/stores.md
@@ -20,7 +20,7 @@ dotnet add package ZeroAlloc.Scheduling.InMemory
 
 ```csharp
 services.AddScheduling()
-        .AddSchedulingInMemory()
+        .WithInMemoryStore()
         .AddMyJob();
 ```
 
@@ -36,7 +36,7 @@ dotnet add package ZeroAlloc.Scheduling.EfCore
 
 ```csharp
 services.AddScheduling()
-        .AddSchedulingEfCore(opt =>
+        .WithEfCore(opt =>
             opt.UseSqlite("Data Source=jobs.db"))
         .AddMyJob();
 ```

--- a/docs/stores.md
+++ b/docs/stores.md
@@ -60,7 +60,7 @@ dotnet add package ZeroAlloc.Scheduling.Redis
 
 ```csharp
 services.AddScheduling()
-        .AddSchedulingRedis("localhost:6379")
+        .WithRedis("localhost:6379")
         .AddMyJob();
 ```
 

--- a/src/ZeroAlloc.Scheduling.Dashboard/JobsDashboardExtensions.cs
+++ b/src/ZeroAlloc.Scheduling.Dashboard/JobsDashboardExtensions.cs
@@ -27,7 +27,7 @@ public static class JobsDashboardExtensions
                 .CreateLogger(typeof(JobsDashboardExtensions));
             logger.LogWarning(
                 "No IJobDashboardStore registered. Dashboard will show empty data. " +
-                "Add AddSchedulingEfCore() or AddSchedulingInMemory() to enable dashboard queries.");
+                "Add .WithEfCore(...) or .WithInMemoryStore() to your AddScheduling() chain to enable dashboard queries.");
         }
 
         return group;

--- a/src/ZeroAlloc.Scheduling.EfCore/EfCoreSchedulingServiceCollectionExtensions.cs
+++ b/src/ZeroAlloc.Scheduling.EfCore/EfCoreSchedulingServiceCollectionExtensions.cs
@@ -8,6 +8,24 @@ namespace ZeroAlloc.Scheduling.EfCore;
 
 public static class EfCoreSchedulingServiceCollectionExtensions
 {
+    /// <summary>
+    /// Registers EF Core-backed scheduling services on the given <see cref="ISchedulingBuilder"/>.
+    /// </summary>
+    public static ISchedulingBuilder WithEfCore(
+        this ISchedulingBuilder builder,
+        Action<DbContextOptionsBuilder> configure)
+    {
+        builder.Services.AddDbContext<SchedulingDbContext>(configure);
+        builder.Services.TryAddScoped<IJobStore, EfCoreJobStore>();
+        builder.Services.TryAddScoped<IJobDashboardStore>(sp => (IJobDashboardStore)sp.GetRequiredService<IJobStore>());
+        return builder;
+    }
+
+    /// <summary>
+    /// Legacy shim that preserves the v1.x extension shape on <see cref="IServiceCollection"/>.
+    /// Will be removed in the next major.
+    /// </summary>
+    [Obsolete("Use AddScheduling().WithEfCore(...) instead. Will be removed in the next major.", DiagnosticId = "ZASCH002")]
     public static IServiceCollection AddSchedulingEfCore(
         this IServiceCollection services,
         Action<DbContextOptionsBuilder> configure)
@@ -19,15 +37,43 @@ public static class EfCoreSchedulingServiceCollectionExtensions
     }
 
     /// <summary>
+    /// Legacy shim that preserves the v1.x extension name when chained from
+    /// <see cref="ISchedulingBuilder"/>. Delegates to <see cref="WithEfCore"/>.
+    /// Will be removed in the next major.
+    /// </summary>
+    [Obsolete("Use AddScheduling().WithEfCore(...) instead. Will be removed in the next major.", DiagnosticId = "ZASCH002")]
+    public static ISchedulingBuilder AddSchedulingEfCore(
+        this ISchedulingBuilder builder,
+        Action<DbContextOptionsBuilder> configure)
+        => builder.WithEfCore(configure);
+
+    /// <summary>
     /// Registers <see cref="IOutboxWriter{TJob}"/> so that a job of type
     /// <typeparamref name="TJob"/> can be enqueued into the outbox store within the same
     /// <c>DbTransaction</c> as a business write (Scheduling#17).
     /// </summary>
     /// <remarks>
     /// Requires <see cref="IOutboxStore"/> and <see cref="IOutboxSerializer"/> to be
-    /// registered in the DI container (e.g. via <c>AddOutbox()</c> + <c>AddOutboxEfCore()</c>
+    /// registered in the DI container (e.g. via <c>AddOutbox()</c> + <c>WithEfCore()</c>
     /// from <c>ZeroAlloc.Outbox</c>).
     /// </remarks>
+    [RequiresUnreferencedCode("Serialization may require types that cannot be statically analyzed.")]
+    [RequiresDynamicCode("Serialization may require dynamic code generation.")]
+    public static ISchedulingBuilder WithOutboxWriter<TJob>(
+        this ISchedulingBuilder builder)
+        where TJob : notnull
+    {
+#pragma warning disable IL2026, IL2091
+        builder.Services.TryAddScoped<IOutboxWriter<TJob>, OutboxJobWriter<TJob>>();
+#pragma warning restore IL2026, IL2091
+        return builder;
+    }
+
+    /// <summary>
+    /// Legacy shim that preserves the v1.x extension shape on <see cref="IServiceCollection"/>.
+    /// Will be removed in the next major.
+    /// </summary>
+    [Obsolete("Use AddScheduling().WithOutboxWriter<TJob>() instead. Will be removed in the next major.", DiagnosticId = "ZASCH003")]
     [RequiresUnreferencedCode("Serialization may require types that cannot be statically analyzed.")]
     [RequiresDynamicCode("Serialization may require dynamic code generation.")]
     public static IServiceCollection AddSchedulingOutboxWriter<TJob>(
@@ -39,4 +85,17 @@ public static class EfCoreSchedulingServiceCollectionExtensions
 #pragma warning restore IL2026, IL2091
         return services;
     }
+
+    /// <summary>
+    /// Legacy shim that preserves the v1.x extension name when chained from
+    /// <see cref="ISchedulingBuilder"/>. Delegates to <see cref="WithOutboxWriter{TJob}"/>.
+    /// Will be removed in the next major.
+    /// </summary>
+    [Obsolete("Use AddScheduling().WithOutboxWriter<TJob>() instead. Will be removed in the next major.", DiagnosticId = "ZASCH003")]
+    [RequiresUnreferencedCode("Serialization may require types that cannot be statically analyzed.")]
+    [RequiresDynamicCode("Serialization may require dynamic code generation.")]
+    public static ISchedulingBuilder AddSchedulingOutboxWriter<TJob>(
+        this ISchedulingBuilder builder)
+        where TJob : notnull
+        => builder.WithOutboxWriter<TJob>();
 }

--- a/src/ZeroAlloc.Scheduling.Generator/SchedulingCodeWriter.cs
+++ b/src/ZeroAlloc.Scheduling.Generator/SchedulingCodeWriter.cs
@@ -42,6 +42,7 @@ internal static class SchedulingCodeWriter
         sb.AppendLine("using Microsoft.Extensions.DependencyInjection.Extensions;");
         sb.AppendLine("using Microsoft.Extensions.Hosting;");
         sb.AppendLine("using Microsoft.Extensions.Options;");
+        sb.AppendLine("using ZeroAlloc.Scheduling;");
         sb.AppendLine();
 
         if (ns != null)
@@ -113,21 +114,31 @@ internal static class SchedulingCodeWriter
     {
         sb.AppendLine("public static partial class SchedulingServiceCollectionExtensions");
         sb.AppendLine("{");
-        sb.AppendLine($"    public static global::Microsoft.Extensions.DependencyInjection.IServiceCollection {diMethodName}(");
-        sb.AppendLine("        this global::Microsoft.Extensions.DependencyInjection.IServiceCollection services)");
+        sb.AppendLine($"    public static global::ZeroAlloc.Scheduling.ISchedulingBuilder {diMethodName}(");
+        sb.AppendLine("        this global::ZeroAlloc.Scheduling.ISchedulingBuilder builder)");
         sb.AppendLine("    {");
 
         if (isMediatorBridge)
         {
-            sb.AppendLine($"        services.AddTransient<global::ZeroAlloc.Scheduling.IJobTypeExecutor, global::ZeroAlloc.Scheduling.Mediator.MediatorJobTypeExecutor<{typeFqn}>>();");
+            sb.AppendLine($"        builder.Services.AddTransient<global::ZeroAlloc.Scheduling.IJobTypeExecutor, global::ZeroAlloc.Scheduling.Mediator.MediatorJobTypeExecutor<{typeFqn}>>();");
         }
         else
         {
-            sb.AppendLine($"        services.AddTransient<global::ZeroAlloc.Scheduling.IJobTypeExecutor, {executorName}>();");
+            sb.AppendLine($"        builder.Services.AddTransient<global::ZeroAlloc.Scheduling.IJobTypeExecutor, {executorName}>();");
         }
 
         if (isRecurring)
-            sb.AppendLine($"        services.AddHostedService<{startupName}>();");
+            sb.AppendLine($"        builder.Services.AddHostedService<{startupName}>();");
+        sb.AppendLine("        return builder;");
+        sb.AppendLine("    }");
+        sb.AppendLine();
+        sb.AppendLine($"    [global::System.Obsolete(\"Use AddScheduling().{diMethodName}() instead. Will be removed in the next major.\", DiagnosticId = \"ZASCH010\")]");
+        sb.AppendLine("    [global::System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(\"AddScheduling may register DefaultJobSerializer which uses reflection-based JSON. Call services.AddSerializerDispatcher() first for AOT-safe serialisation.\")]");
+        sb.AppendLine("    [global::System.Diagnostics.CodeAnalysis.RequiresDynamicCode(\"AddScheduling may register DefaultJobSerializer which may require runtime code generation. Call services.AddSerializerDispatcher() first for AOT-safe serialisation.\")]");
+        sb.AppendLine($"    public static global::Microsoft.Extensions.DependencyInjection.IServiceCollection {diMethodName}(");
+        sb.AppendLine("        this global::Microsoft.Extensions.DependencyInjection.IServiceCollection services)");
+        sb.AppendLine("    {");
+        sb.AppendLine($"        services.AddScheduling().{diMethodName}();");
         sb.AppendLine("        return services;");
         sb.AppendLine("    }");
         sb.AppendLine("}");

--- a/src/ZeroAlloc.Scheduling.InMemory/InMemorySchedulingServiceCollectionExtensions.cs
+++ b/src/ZeroAlloc.Scheduling.InMemory/InMemorySchedulingServiceCollectionExtensions.cs
@@ -5,9 +5,32 @@ namespace ZeroAlloc.Scheduling.InMemory;
 
 public static class InMemorySchedulingServiceCollectionExtensions
 {
+    /// <summary>
+    /// Registers the in-memory <see cref="IJobStore"/> against the scheduling builder.
+    /// </summary>
+    public static ISchedulingBuilder WithInMemoryStore(this ISchedulingBuilder builder)
+    {
+        builder.Services.TryAddSingleton<IJobStore, InMemoryJobStore>();
+        return builder;
+    }
+
+    /// <summary>
+    /// Legacy shim that preserves the v1.x extension shape on <see cref="IServiceCollection"/>.
+    /// Will be removed in the next major.
+    /// </summary>
+    [Obsolete("Use AddScheduling().WithInMemoryStore() instead. Will be removed in the next major.", DiagnosticId = "ZASCH001")]
     public static IServiceCollection AddSchedulingInMemory(this IServiceCollection services)
     {
         services.TryAddSingleton<IJobStore, InMemoryJobStore>();
         return services;
     }
+
+    /// <summary>
+    /// Legacy shim that preserves the v1.x extension name when chained from
+    /// <see cref="ISchedulingBuilder"/> (post-builder return-type change). Delegates to
+    /// <see cref="WithInMemoryStore"/>. Will be removed in the next major.
+    /// </summary>
+    [Obsolete("Use AddScheduling().WithInMemoryStore() instead. Will be removed in the next major.", DiagnosticId = "ZASCH001")]
+    public static ISchedulingBuilder AddSchedulingInMemory(this ISchedulingBuilder builder)
+        => builder.WithInMemoryStore();
 }

--- a/src/ZeroAlloc.Scheduling.Mediator/MediatorSchedulingExtensions.cs
+++ b/src/ZeroAlloc.Scheduling.Mediator/MediatorSchedulingExtensions.cs
@@ -5,7 +5,8 @@ namespace ZeroAlloc.Scheduling.Mediator;
 public static class MediatorSchedulingExtensions
 {
     /// <summary>
-    /// Registers the ZeroAlloc.Scheduling mediator bridge.
+    /// Marker entrypoint for the ZeroAlloc.Scheduling mediator bridge on
+    /// <see cref="ISchedulingBuilder"/>.
     /// <para>
     /// Job types decorated with <c>[Job]</c> that also implement <c>IRequest&lt;Unit&gt;</c>
     /// have their <see cref="MediatorJobTypeExecutor{TJob}"/> registered automatically
@@ -16,8 +17,27 @@ public static class MediatorSchedulingExtensions
     /// removed from application startup code.
     /// </para>
     /// </summary>
+    public static ISchedulingBuilder WithMediator(this ISchedulingBuilder builder)
+    {
+        return builder;
+    }
+
+    /// <summary>
+    /// Legacy shim that preserves the v1.x extension shape on <see cref="IServiceCollection"/>.
+    /// Will be removed in the next major.
+    /// </summary>
+    [Obsolete("Use AddScheduling().WithMediator() instead. Will be removed in the next major.", DiagnosticId = "ZASCH004")]
     public static IServiceCollection AddSchedulingMediator(this IServiceCollection services)
     {
         return services;
     }
+
+    /// <summary>
+    /// Legacy shim that preserves the v1.x extension name when chained from
+    /// <see cref="ISchedulingBuilder"/>. Delegates to <see cref="WithMediator"/>.
+    /// Will be removed in the next major.
+    /// </summary>
+    [Obsolete("Use AddScheduling().WithMediator() instead. Will be removed in the next major.", DiagnosticId = "ZASCH004")]
+    public static ISchedulingBuilder AddSchedulingMediator(this ISchedulingBuilder builder)
+        => builder.WithMediator();
 }

--- a/src/ZeroAlloc.Scheduling.Redis/RedisSchedulingServiceCollectionExtensions.cs
+++ b/src/ZeroAlloc.Scheduling.Redis/RedisSchedulingServiceCollectionExtensions.cs
@@ -6,6 +6,25 @@ namespace ZeroAlloc.Scheduling.Redis;
 
 public static class RedisSchedulingServiceCollectionExtensions
 {
+    /// <summary>
+    /// Registers the Redis <see cref="IJobStore"/> against the scheduling builder.
+    /// </summary>
+    public static ISchedulingBuilder WithRedis(
+        this ISchedulingBuilder builder,
+        string connectionString)
+    {
+        builder.Services.AddSingleton<IConnectionMultiplexer>(_ => ConnectionMultiplexer.Connect(connectionString));
+        builder.Services.TryAddSingleton<IDatabase>(sp => sp.GetRequiredService<IConnectionMultiplexer>().GetDatabase());
+        builder.Services.TryAddSingleton<IJobStore, RedisJobStore>();
+        builder.Services.TryAddSingleton<IJobDashboardStore>(sp => (IJobDashboardStore)sp.GetRequiredService<IJobStore>());
+        return builder;
+    }
+
+    /// <summary>
+    /// Legacy shim that preserves the v1.x extension shape on <see cref="IServiceCollection"/>.
+    /// Will be removed in the next major.
+    /// </summary>
+    [Obsolete("Use AddScheduling().WithRedis(connectionString) instead. Will be removed in the next major.", DiagnosticId = "ZASCH006")]
     public static IServiceCollection AddSchedulingRedis(
         this IServiceCollection services,
         string connectionString)
@@ -16,4 +35,15 @@ public static class RedisSchedulingServiceCollectionExtensions
         services.TryAddSingleton<IJobDashboardStore>(sp => (IJobDashboardStore)sp.GetRequiredService<IJobStore>());
         return services;
     }
+
+    /// <summary>
+    /// Legacy shim that preserves the v1.x extension name when chained from
+    /// <see cref="ISchedulingBuilder"/> (post-builder return-type change). Delegates to
+    /// <see cref="WithRedis"/>. Will be removed in the next major.
+    /// </summary>
+    [Obsolete("Use AddScheduling().WithRedis(connectionString) instead. Will be removed in the next major.", DiagnosticId = "ZASCH006")]
+    public static ISchedulingBuilder AddSchedulingRedis(
+        this ISchedulingBuilder builder,
+        string connectionString)
+        => builder.WithRedis(connectionString);
 }

--- a/src/ZeroAlloc.Scheduling.Resilience/SchedulingResilienceServiceCollectionExtensions.cs
+++ b/src/ZeroAlloc.Scheduling.Resilience/SchedulingResilienceServiceCollectionExtensions.cs
@@ -6,7 +6,8 @@ public static class SchedulingResilienceServiceCollectionExtensions
 {
     /// <summary>
     /// Registers a Resilience-generated proxy <typeparamref name="TResilienceProxy"/> as the
-    /// <see cref="IJobTypeExecutor"/> for a specific job type.
+    /// <see cref="IJobTypeExecutor"/> for a specific job type, using the fluent
+    /// <see cref="ISchedulingBuilder"/> pipeline.
     /// </summary>
     /// <typeparam name="TExecutorInterface">
     /// A custom executor interface that extends <see cref="IJobTypeExecutor"/> and carries
@@ -30,11 +31,26 @@ public static class SchedulingResilienceServiceCollectionExtensions
     /// // 3. Register in DI (the Resilience generator emits ISendEmailJobExecutorResilienceProxy):
     /// services
     ///     .AddScheduling()
-    ///     .AddSchedulingResilience&lt;ISendEmailJobExecutor, ISendEmailJobExecutorResilienceProxy&gt;();
+    ///     .WithResilience&lt;ISendEmailJobExecutor, ISendEmailJobExecutorResilienceProxy&gt;();
     /// </code>
     /// The proxy wraps the inner <typeparamref name="TExecutorInterface"/> implementation and
     /// is resolved as <see cref="IJobTypeExecutor"/> by the scheduling worker.
     /// </remarks>
+    public static ISchedulingBuilder WithResilience<TExecutorInterface, TResilienceProxy>(
+        this ISchedulingBuilder builder)
+        where TExecutorInterface : class, IJobTypeExecutor
+        where TResilienceProxy : class, TExecutorInterface
+    {
+        builder.Services.AddTransient<TResilienceProxy>();
+        builder.Services.AddTransient<IJobTypeExecutor>(sp => sp.GetRequiredService<TResilienceProxy>());
+        return builder;
+    }
+
+    /// <summary>
+    /// Legacy shim that preserves the v1.x extension shape on <see cref="IServiceCollection"/>.
+    /// Will be removed in the next major.
+    /// </summary>
+    [Obsolete("Use AddScheduling().WithResilience<TInterface, TProxy>() instead. Will be removed in the next major.", DiagnosticId = "ZASCH005")]
     public static IServiceCollection AddSchedulingResilience<TExecutorInterface, TResilienceProxy>(
         this IServiceCollection services)
         where TExecutorInterface : class, IJobTypeExecutor
@@ -44,4 +60,17 @@ public static class SchedulingResilienceServiceCollectionExtensions
         services.AddTransient<IJobTypeExecutor>(sp => sp.GetRequiredService<TResilienceProxy>());
         return services;
     }
+
+    /// <summary>
+    /// Legacy shim that preserves the v1.x extension name when chained from
+    /// <see cref="ISchedulingBuilder"/>. Delegates to
+    /// <see cref="WithResilience{TExecutorInterface, TResilienceProxy}"/>.
+    /// Will be removed in the next major.
+    /// </summary>
+    [Obsolete("Use AddScheduling().WithResilience<TInterface, TProxy>() instead. Will be removed in the next major.", DiagnosticId = "ZASCH005")]
+    public static ISchedulingBuilder AddSchedulingResilience<TExecutorInterface, TResilienceProxy>(
+        this ISchedulingBuilder builder)
+        where TExecutorInterface : class, IJobTypeExecutor
+        where TResilienceProxy : class, TExecutorInterface
+        => builder.WithResilience<TExecutorInterface, TResilienceProxy>();
 }

--- a/src/ZeroAlloc.Scheduling/ISchedulingBuilder.cs
+++ b/src/ZeroAlloc.Scheduling/ISchedulingBuilder.cs
@@ -1,0 +1,13 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace ZeroAlloc.Scheduling;
+
+/// <summary>
+/// Fluent builder returned by <see cref="SchedulingServiceCollectionExtensions.AddScheduling"/>.
+/// Exposes the underlying <see cref="IServiceCollection"/> via <see cref="Services"/>;
+/// downstream packages add <c>With*</c> extensions on this interface.
+/// </summary>
+public interface ISchedulingBuilder
+{
+    IServiceCollection Services { get; }
+}

--- a/src/ZeroAlloc.Scheduling/SchedulingBuilder.cs
+++ b/src/ZeroAlloc.Scheduling/SchedulingBuilder.cs
@@ -1,0 +1,8 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace ZeroAlloc.Scheduling;
+
+internal sealed class SchedulingBuilder(IServiceCollection services) : ISchedulingBuilder
+{
+    public IServiceCollection Services { get; } = services;
+}

--- a/src/ZeroAlloc.Scheduling/SchedulingServiceCollectionExtensions.cs
+++ b/src/ZeroAlloc.Scheduling/SchedulingServiceCollectionExtensions.cs
@@ -23,7 +23,7 @@ public static partial class SchedulingServiceCollectionExtensions
     /// </remarks>
     [RequiresUnreferencedCode("AddScheduling may register DefaultJobSerializer which uses reflection-based JSON. Call services.AddSerializerDispatcher() first for AOT-safe serialisation.")]
     [RequiresDynamicCode("AddScheduling may register DefaultJobSerializer which may require runtime code generation. Call services.AddSerializerDispatcher() first for AOT-safe serialisation.")]
-    public static IServiceCollection AddScheduling(
+    public static ISchedulingBuilder AddScheduling(
         this IServiceCollection services,
         Action<SchedulingOptions>? configure = null)
     {
@@ -55,6 +55,6 @@ public static partial class SchedulingServiceCollectionExtensions
         services.AddSingleton<SchedulingWorkerService>();
         services.AddHostedService(sp => sp.GetRequiredService<SchedulingWorkerService>());
 
-        return services;
+        return new SchedulingBuilder(services);
     }
 }

--- a/tests/ZeroAlloc.Scheduling.Dashboard.Tests/Program.cs
+++ b/tests/ZeroAlloc.Scheduling.Dashboard.Tests/Program.cs
@@ -9,8 +9,7 @@ var builder = WebApplication.CreateBuilder(new WebApplicationOptions
     Args = args,
     ContentRootPath = AppContext.BaseDirectory,
 });
-builder.Services.AddScheduling();
-builder.Services.AddSchedulingInMemory();
+builder.Services.AddScheduling().WithInMemoryStore();
 builder.Services.AddRouting();
 
 var app = builder.Build();

--- a/tests/ZeroAlloc.Scheduling.Dashboard.Tests/ZeroAlloc.Scheduling.Dashboard.Tests.csproj
+++ b/tests/ZeroAlloc.Scheduling.Dashboard.Tests/ZeroAlloc.Scheduling.Dashboard.Tests.csproj
@@ -3,6 +3,8 @@
     <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <GenerateProgramFile>false</GenerateProgramFile>
+    <!-- Builder-pattern migration: legacy [Obsolete] shims emit custom DiagnosticIds that #pragma cannot suppress while TreatWarningsAsErrors=true. -->
+    <NoWarn>$(NoWarn);ZASCH001;ZASCH002;ZASCH003;ZASCH004;ZASCH005</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />

--- a/tests/ZeroAlloc.Scheduling.EfCore.Tests/WithEfCoreTests.cs
+++ b/tests/ZeroAlloc.Scheduling.EfCore.Tests/WithEfCoreTests.cs
@@ -1,0 +1,99 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using ZeroAlloc.Outbox;
+using ZeroAlloc.Scheduling.EfCore;
+
+namespace ZeroAlloc.Scheduling.EfCore.Tests;
+
+/// <summary>
+/// Verifies the builder-pattern entrypoints in <see cref="EfCoreSchedulingServiceCollectionExtensions"/>:
+/// <c>WithEfCore</c>, <c>WithOutboxWriter&lt;TJob&gt;</c>, and their legacy <c>AddSchedulingEfCore</c> /
+/// <c>AddSchedulingOutboxWriter</c> shims.
+/// </summary>
+public sealed class WithEfCoreTests
+{
+    private sealed record SampleJob(string Name);
+
+    [Fact]
+    public void WithEfCore_RegistersJobStore()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+#pragma warning disable IL2026, IL3050
+        services.AddScheduling()
+                .WithEfCore(o => o.UseSqlite("DataSource=:memory:"));
+#pragma warning restore IL2026, IL3050
+
+        using var scope = services.BuildServiceProvider().CreateScope();
+        scope.ServiceProvider.GetService<IJobStore>().Should().NotBeNull();
+    }
+
+    [Fact]
+    public void AddSchedulingEfCore_LegacyShim_StillRegistersJobStore()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        services.AddSchedulingEfCore(o => o.UseSqlite("DataSource=:memory:"));
+
+        using var scope = services.BuildServiceProvider().CreateScope();
+        scope.ServiceProvider.GetService<IJobStore>().Should().NotBeNull();
+    }
+
+    [Fact]
+    public void WithOutboxWriter_RegistersIOutboxWriter()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<IOutboxStore, NoopOutboxStore>();
+        services.AddSingleton<IOutboxSerializer, NoopOutboxSerializer>();
+
+#pragma warning disable IL2026, IL2091, IL3050
+        services.AddScheduling()
+                .WithOutboxWriter<SampleJob>();
+#pragma warning restore IL2026, IL2091, IL3050
+
+        using var scope = services.BuildServiceProvider().CreateScope();
+        scope.ServiceProvider.GetRequiredService<IOutboxWriter<SampleJob>>().Should().NotBeNull();
+    }
+
+    [Fact]
+    public void AddSchedulingOutboxWriter_LegacyShim_StillRegistersWriter()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<IOutboxStore, NoopOutboxStore>();
+        services.AddSingleton<IOutboxSerializer, NoopOutboxSerializer>();
+
+#pragma warning disable IL2026, IL2091
+        services.AddSchedulingOutboxWriter<SampleJob>();
+#pragma warning restore IL2026, IL2091
+
+        using var scope = services.BuildServiceProvider().CreateScope();
+        scope.ServiceProvider.GetRequiredService<IOutboxWriter<SampleJob>>().Should().NotBeNull();
+    }
+
+    private sealed class NoopOutboxStore : IOutboxStore
+    {
+        public ValueTask EnqueueAsync(string typeName, ReadOnlyMemory<byte> payload,
+            System.Data.Common.DbTransaction? transaction, CancellationToken ct)
+            => ValueTask.CompletedTask;
+
+        public ValueTask<IReadOnlyList<OutboxEntry>> FetchPendingAsync(int batchSize, CancellationToken ct)
+            => ValueTask.FromResult<IReadOnlyList<OutboxEntry>>([]);
+
+        public ValueTask MarkSucceededAsync(OutboxMessageId id, CancellationToken ct) => ValueTask.CompletedTask;
+        public ValueTask MarkFailedAsync(OutboxMessageId id, int retryCount, DateTimeOffset nextRetryAt, CancellationToken ct) => ValueTask.CompletedTask;
+        public ValueTask DeadLetterAsync(OutboxMessageId id, string error, CancellationToken ct) => ValueTask.CompletedTask;
+    }
+
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Trimming", "IL2026", Justification = "Test code.")]
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("AOT", "IL3050", Justification = "Test code.")]
+    private sealed class NoopOutboxSerializer : IOutboxSerializer
+    {
+        public ReadOnlyMemory<byte> Serialize<T>(T value)
+            => System.Text.Json.JsonSerializer.SerializeToUtf8Bytes(value);
+
+        public T Deserialize<T>(ReadOnlyMemory<byte> data)
+            => System.Text.Json.JsonSerializer.Deserialize<T>(data.Span)!;
+    }
+}

--- a/tests/ZeroAlloc.Scheduling.EfCore.Tests/ZeroAlloc.Scheduling.EfCore.Tests.csproj
+++ b/tests/ZeroAlloc.Scheduling.EfCore.Tests/ZeroAlloc.Scheduling.EfCore.Tests.csproj
@@ -2,6 +2,8 @@
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
+    <!-- Builder-pattern migration: legacy [Obsolete] shims emit custom DiagnosticIds that #pragma cannot suppress while TreatWarningsAsErrors=true. -->
+    <NoWarn>$(NoWarn);ZASCH001;ZASCH002;ZASCH003;ZASCH004;ZASCH005</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />

--- a/tests/ZeroAlloc.Scheduling.Resilience.Tests/WithResilienceTests.cs
+++ b/tests/ZeroAlloc.Scheduling.Resilience.Tests/WithResilienceTests.cs
@@ -1,0 +1,65 @@
+using Microsoft.Extensions.DependencyInjection;
+using ZeroAlloc.Scheduling;
+using ZeroAlloc.Scheduling.Resilience;
+
+namespace ZeroAlloc.Scheduling.Resilience.Tests;
+
+/// <summary>
+/// Validates that the <see cref="ISchedulingBuilder"/>-shaped <c>WithResilience</c> entrypoint
+/// wires the Resilience proxy as <see cref="IJobTypeExecutor"/>, and the legacy
+/// <c>AddSchedulingResilience</c> shim still works.
+/// </summary>
+public class WithResilienceTests
+{
+    [Fact]
+    public void WithResilience_RegistersProxyAsExecutor()
+    {
+        var services = new ServiceCollection();
+        services.AddTransient<SendEmailJobExecutorImpl>();
+
+#pragma warning disable IL2026, IL3050
+        services.AddScheduling()
+                .WithResilience<ISendEmailJobExecutor, SendEmailJobExecutorProxy>();
+#pragma warning restore IL2026, IL3050
+
+        var provider = services.BuildServiceProvider();
+        provider.GetRequiredService<IJobTypeExecutor>()
+                .Should().BeOfType<SendEmailJobExecutorProxy>();
+    }
+
+    [Fact]
+    public void AddSchedulingResilience_LegacyShim_RegistersProxyAsExecutor()
+    {
+        var services = new ServiceCollection();
+        services.AddTransient<SendEmailJobExecutorImpl>();
+
+        services.AddSchedulingResilience<ISendEmailJobExecutor, SendEmailJobExecutorProxy>();
+
+        var provider = services.BuildServiceProvider();
+        provider.GetRequiredService<IJobTypeExecutor>()
+                .Should().BeOfType<SendEmailJobExecutorProxy>();
+    }
+
+    // ---- Supporting types (mirror SchedulingResilienceExtensionsTests) ----
+
+    public interface ISendEmailJobExecutor : IJobTypeExecutor { }
+
+    public sealed class SendEmailJobExecutorImpl : ISendEmailJobExecutor
+    {
+        public string TypeName => "SendEmail";
+        public int MaxAttempts => 0;
+
+        public ValueTask ExecuteAsync(byte[] payload, JobContext ctx, CancellationToken ct)
+            => ValueTask.CompletedTask;
+    }
+
+    public sealed class SendEmailJobExecutorProxy : ISendEmailJobExecutor
+    {
+        public SendEmailJobExecutorImpl Inner { get; }
+        public SendEmailJobExecutorProxy(SendEmailJobExecutorImpl inner) => Inner = inner;
+        public string TypeName => Inner.TypeName;
+        public int MaxAttempts => Inner.MaxAttempts;
+        public ValueTask ExecuteAsync(byte[] payload, JobContext ctx, CancellationToken ct)
+            => Inner.ExecuteAsync(payload, ctx, ct);
+    }
+}

--- a/tests/ZeroAlloc.Scheduling.Resilience.Tests/ZeroAlloc.Scheduling.Resilience.Tests.csproj
+++ b/tests/ZeroAlloc.Scheduling.Resilience.Tests/ZeroAlloc.Scheduling.Resilience.Tests.csproj
@@ -2,6 +2,8 @@
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
+    <!-- Builder-pattern migration: legacy [Obsolete] shims emit custom DiagnosticIds that #pragma cannot suppress while TreatWarningsAsErrors=true. -->
+    <NoWarn>$(NoWarn);ZASCH001;ZASCH002;ZASCH003;ZASCH004;ZASCH005</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />

--- a/tests/ZeroAlloc.Scheduling.Tests/MediatorBridgeTests.cs
+++ b/tests/ZeroAlloc.Scheduling.Tests/MediatorBridgeTests.cs
@@ -27,8 +27,8 @@ public sealed class MediatorBridgeTests
 
         var services = new ServiceCollection()
             .AddScheduling()
-            .AddSchedulingInMemory()
-            .BuildServiceProvider();
+            .WithInMemoryStore()
+            .Services.BuildServiceProvider();
 
         var ctx = new JobContext
         {

--- a/tests/ZeroAlloc.Scheduling.Tests/SchedulingBuilderTests.cs
+++ b/tests/ZeroAlloc.Scheduling.Tests/SchedulingBuilderTests.cs
@@ -2,6 +2,7 @@ using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using ZeroAlloc.Scheduling;
 using ZeroAlloc.Scheduling.InMemory;
+using ZeroAlloc.Scheduling.Mediator;
 
 namespace ZeroAlloc.Scheduling.Tests;
 
@@ -41,5 +42,28 @@ public class SchedulingBuilderTests
         services.AddSchedulingInMemory();
 
         services.BuildServiceProvider().GetService<IJobStore>().Should().NotBeNull();
+    }
+
+    [Fact]
+    public void WithMediator_ReturnsSameBuilder()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        var builder = services.AddScheduling();
+        var result = builder.WithMediator();
+
+        result.Should().BeSameAs(builder);
+    }
+
+    [Fact]
+    public void AddSchedulingMediator_LegacyShim_ReturnsSameServices()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        var result = services.AddSchedulingMediator();
+
+        result.Should().BeSameAs(services);
     }
 }

--- a/tests/ZeroAlloc.Scheduling.Tests/SchedulingBuilderTests.cs
+++ b/tests/ZeroAlloc.Scheduling.Tests/SchedulingBuilderTests.cs
@@ -1,0 +1,21 @@
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using ZeroAlloc.Scheduling;
+
+namespace ZeroAlloc.Scheduling.Tests;
+
+public class SchedulingBuilderTests
+{
+    [Fact]
+    public void AddScheduling_ReturnsBuilder_BackedBySameServiceCollection()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        var builder = services.AddScheduling();
+
+        builder.Should().NotBeNull();
+        builder.Should().BeAssignableTo<ISchedulingBuilder>();
+        builder.Services.Should().BeSameAs(services);
+    }
+}

--- a/tests/ZeroAlloc.Scheduling.Tests/SchedulingBuilderTests.cs
+++ b/tests/ZeroAlloc.Scheduling.Tests/SchedulingBuilderTests.cs
@@ -1,6 +1,7 @@
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using ZeroAlloc.Scheduling;
+using ZeroAlloc.Scheduling.InMemory;
 
 namespace ZeroAlloc.Scheduling.Tests;
 
@@ -17,5 +18,28 @@ public class SchedulingBuilderTests
         builder.Should().NotBeNull();
         builder.Should().BeAssignableTo<ISchedulingBuilder>();
         builder.Services.Should().BeSameAs(services);
+    }
+
+    [Fact]
+    public void WithInMemoryStore_RegistersInMemoryStore()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        services.AddScheduling().WithInMemoryStore();
+
+        var sp = services.BuildServiceProvider();
+        sp.GetService<IJobStore>().Should().NotBeNull();
+    }
+
+    [Fact]
+    public void AddSchedulingInMemory_LegacyShim_StillRegistersStore()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        services.AddSchedulingInMemory();
+
+        services.BuildServiceProvider().GetService<IJobStore>().Should().NotBeNull();
     }
 }

--- a/tests/ZeroAlloc.Scheduling.Tests/SchedulingWorkerServiceTests.cs
+++ b/tests/ZeroAlloc.Scheduling.Tests/SchedulingWorkerServiceTests.cs
@@ -24,7 +24,7 @@ public sealed class SchedulingWorkerServiceTests
             .AddSingleton<IJobStore>(store)
             .AddSingleton<IJobTypeExecutor>(executor)
             .AddScheduling(o => o.PollingInterval = TimeSpan.FromMilliseconds(50))
-            .BuildServiceProvider();
+            .Services.BuildServiceProvider();
 
         await store.EnqueueAsync("TestJob", [], DateTimeOffset.UtcNow, 3, null, CancellationToken.None);
 
@@ -59,7 +59,7 @@ public sealed class SchedulingWorkerServiceTests
                 o.RetryBaseDelay = TimeSpan.FromMilliseconds(1);
                 o.DefaultMaxAttempts = 3;
             })
-            .BuildServiceProvider();
+            .Services.BuildServiceProvider();
 
         await store.EnqueueAsync("FailJob", [], DateTimeOffset.UtcNow, 3, null, CancellationToken.None);
 

--- a/tests/ZeroAlloc.Scheduling.Tests/ZeroAlloc.Scheduling.Tests.csproj
+++ b/tests/ZeroAlloc.Scheduling.Tests/ZeroAlloc.Scheduling.Tests.csproj
@@ -2,6 +2,8 @@
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
+    <!-- Builder-pattern migration: legacy [Obsolete] shims emit custom DiagnosticIds that #pragma cannot suppress while TreatWarningsAsErrors=true. -->
+    <NoWarn>$(NoWarn);ZASCH001;ZASCH002;ZASCH003;ZASCH004;ZASCH005</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />


### PR DESCRIPTION
## Summary
Migrates `ZeroAlloc.Scheduling` DI registration from `IServiceCollection`-extension methods to a fluent builder pattern (`ISchedulingBuilder`). Subscribers chain `AddScheduling().WithInMemoryStore().AddMyJob().WithMediator().WithResilience<...>()` instead of repeating `services.` for each registration. Mirrors the `ZeroAlloc.Outbox` v2 migration (PR #31). Closes no tracking issues directly; unblocks the Scheduling half of the [Telemetry Bridge Packages design](../docs/plans/2026-04-25-telemetry-bridge-packages-design.md).

## Breaking changes
- `AddScheduling(...)` now returns `ISchedulingBuilder` (was `IServiceCollection`). Use `.Services` to recover.
- All `Add*` sub-registrations renamed to `With*` on the builder: `WithInMemoryStore`, `WithEfCore`, `WithOutboxWriter<TJob>`, `WithMediator`, `WithResilience<TInterface, TProxy>`, `WithRedis`.
- Generator-emitted `Add{TJob}Job` now operates on `ISchedulingBuilder`.
- All v1.x extensions retained as `[Obsolete]` shims with stable diagnostic IDs (`ZASCH001`–`ZASCH010`); will be removed in the next major.
- Generator-emitted IServiceCollection shim correctly propagates `[RequiresUnreferencedCode]`/`[RequiresDynamicCode]` so AOT publish stays clean.

## Migration
See `docs/getting-started.md` "Migrating from v1.x" section.

## Test plan
- [x] Builder identity tests (`SchedulingBuilderTests`)
- [x] Per-extension migration tests + back-compat shim tests
- [x] AOT IL analysis clean (no IL2026/IL3050 from generator output)
- [x] 64/64 tests passing across all 5 Scheduling test projects

🤖 Generated with [Claude Code](https://claude.com/claude-code)