### PR TITLE
feat(scheduling)!: finish JobId migration on entity, dashboard, and Redis (#20)

### DIFF
--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -46,6 +46,8 @@ The dashboard is served from an embedded resource (no static file middleware req
 | `POST /jobs/api/{id}/requeue` | Re-enqueue a dead-lettered job |
 | `DELETE /jobs/api/{id}` | Delete a job |
 
+The `{id}` route segment binds to a strongly-typed `JobId`, which serializes as a 26-character ULID base32 string (e.g. `01H8XGJWBWBAQ4ZQ8Y9ABZ35TX`). URLs that embed the legacy `Guid` format no longer match these routes — clients holding job IDs from a previous version must be refreshed before issuing requeue or delete requests. The Blazor `JobsDashboardClient` already builds these URLs from `JobId.ToString()`, so no caller changes are required when consuming the component.
+
 ### Authentication
 
 `MapJobsDashboard` returns an `IEndpointConventionBuilder`, so standard ASP.NET Core authorization policies apply:

--- a/docs/stores.md
+++ b/docs/stores.md
@@ -66,6 +66,8 @@ services.AddScheduling()
 
 Jobs are stored as Redis hashes. The store maintains three tracking Sets (`jobs:succeeded`, `jobs:failed`, `jobs:deadletter`) for O(1) summary queries without scanning all keys.
 
+> **Upgrade note.** Hash keys are now derived from `JobId.ToString()`, a 26-character ULID base32 string, instead of the previous `Guid` representation. Live deployments must drain the queue (let in-flight jobs complete and stop producing new ones) before upgrading: existing keys written by the older version will not be discovered by the new lookups, so they should be allowed to finish or be cleared explicitly before the rollout.
+
 ## Dashboard Integration
 
 All three stores also implement `IJobDashboardStore`, which powers the dashboard API. EF Core and Redis register `IJobDashboardStore` automatically. InMemory implements it directly on `InMemoryJobStore`.

--- a/src/ZeroAlloc.Scheduling.Dashboard.Blazor/JobsDashboard.razor
+++ b/src/ZeroAlloc.Scheduling.Dashboard.Blazor/JobsDashboard.razor
@@ -72,6 +72,6 @@
         await InvokeAsync(StateHasChanged);
     }
 
-    private async Task RequeueAsync(Guid id) { await Client.RequeueAsync(id); await LoadAsync(); }
-    private async Task DeleteAsync(Guid id)  { await Client.DeleteAsync(id);  await LoadAsync(); }
+    private async Task RequeueAsync(JobId id) { await Client.RequeueAsync(id); await LoadAsync(); }
+    private async Task DeleteAsync(JobId id)  { await Client.DeleteAsync(id);  await LoadAsync(); }
 }

--- a/src/ZeroAlloc.Scheduling.Dashboard.Blazor/JobsDashboardClient.cs
+++ b/src/ZeroAlloc.Scheduling.Dashboard.Blazor/JobsDashboardClient.cs
@@ -44,13 +44,13 @@ public sealed class JobsDashboardClient
         return await response.Content.ReadFromJsonAsync<IReadOnlyList<JobEntry>>(ct).ConfigureAwait(false);
     }
 
-    public async Task RequeueAsync(Guid id, CancellationToken ct = default)
+    public async Task RequeueAsync(JobId id, CancellationToken ct = default)
     {
         using var response = await _http.PostAsync($"{id}/requeue", null, ct).ConfigureAwait(false);
         response.EnsureSuccessStatusCode();
     }
 
-    public async Task DeleteAsync(Guid id, CancellationToken ct = default)
+    public async Task DeleteAsync(JobId id, CancellationToken ct = default)
     {
         using var response = await _http.DeleteAsync($"{id}", ct).ConfigureAwait(false);
         response.EnsureSuccessStatusCode();

--- a/src/ZeroAlloc.Scheduling.Dashboard/JobsDashboardExtensions.cs
+++ b/src/ZeroAlloc.Scheduling.Dashboard/JobsDashboardExtensions.cs
@@ -63,15 +63,15 @@ public static class JobsDashboardExtensions
                 ? Results.Ok(await d.GetRecurringAsync(ct).ConfigureAwait(false))
                 : Results.Ok(Array.Empty<object>()));
 
-        group.MapPost("/api/{id:guid}/requeue", async (Guid id, IJobStore s, CancellationToken ct) =>
+        group.MapPost("/api/{id}/requeue", async (JobId id, IJobStore s, CancellationToken ct) =>
         {
-            if (s is IJobDashboardStore d) await d.RequeueAsync(new JobId(id), ct).ConfigureAwait(false);
+            if (s is IJobDashboardStore d) await d.RequeueAsync(id, ct).ConfigureAwait(false);
             return Results.Ok();
         });
 
-        group.MapDelete("/api/{id:guid}", async (Guid id, IJobStore s, CancellationToken ct) =>
+        group.MapDelete("/api/{id}", async (JobId id, IJobStore s, CancellationToken ct) =>
         {
-            if (s is IJobDashboardStore d) await d.DeleteAsync(new JobId(id), ct).ConfigureAwait(false);
+            if (s is IJobDashboardStore d) await d.DeleteAsync(id, ct).ConfigureAwait(false);
             return Results.Ok();
         });
     }

--- a/src/ZeroAlloc.Scheduling.EfCore/EfCoreJobStore.cs
+++ b/src/ZeroAlloc.Scheduling.EfCore/EfCoreJobStore.cs
@@ -13,7 +13,7 @@ public sealed class EfCoreJobStore : IJobStore, IJobDashboardStore
     {
         _db.Jobs.Add(new JobEntryEntity
         {
-            Id = Guid.NewGuid(), TypeName = typeName, Payload = payload,
+            Id = JobId.New(), TypeName = typeName, Payload = payload,
             Status = JobStatus.Pending, Attempts = 0, MaxAttempts = maxAttempts,
             ScheduledAt = scheduledAt, CronExpression = cronExpression,
         });
@@ -57,7 +57,7 @@ public sealed class EfCoreJobStore : IJobStore, IJobDashboardStore
     public async ValueTask MarkSucceededAsync(JobId id, DateTimeOffset? nextRunAt,
         string? cronExpression, int maxAttempts, CancellationToken ct)
     {
-        var entity = await _db.Jobs.FindAsync(new object[] { id.Value }, ct).ConfigureAwait(false);
+        var entity = await _db.Jobs.FindAsync(new object[] { id }, ct).ConfigureAwait(false);
         if (entity is null) return;
 
         entity.Status = JobStatus.Succeeded;
@@ -67,7 +67,7 @@ public sealed class EfCoreJobStore : IJobStore, IJobDashboardStore
         {
             _db.Jobs.Add(new JobEntryEntity
             {
-                Id = Guid.NewGuid(), TypeName = entity.TypeName, Payload = entity.Payload,
+                Id = JobId.New(), TypeName = entity.TypeName, Payload = entity.Payload,
                 Status = JobStatus.Pending, Attempts = 0, MaxAttempts = maxAttempts,
                 ScheduledAt = nextRunAt.Value, CronExpression = cronExpression,
             });
@@ -77,7 +77,7 @@ public sealed class EfCoreJobStore : IJobStore, IJobDashboardStore
 
     public async ValueTask MarkFailedAsync(JobId id, int attempts, DateTimeOffset nextRetryAt, CancellationToken ct)
     {
-        var entity = await _db.Jobs.FindAsync(new object[] { id.Value }, ct).ConfigureAwait(false);
+        var entity = await _db.Jobs.FindAsync(new object[] { id }, ct).ConfigureAwait(false);
         if (entity is null) return;
         entity.Status = JobStatus.Failed;
         entity.Attempts = attempts;
@@ -87,7 +87,7 @@ public sealed class EfCoreJobStore : IJobStore, IJobDashboardStore
 
     public async ValueTask DeadLetterAsync(JobId id, string error, CancellationToken ct)
     {
-        var entity = await _db.Jobs.FindAsync(new object[] { id.Value }, ct).ConfigureAwait(false);
+        var entity = await _db.Jobs.FindAsync(new object[] { id }, ct).ConfigureAwait(false);
         if (entity is null) return;
         entity.Status = JobStatus.DeadLetter;
         entity.CompletedAt = DateTimeOffset.UtcNow;
@@ -106,7 +106,7 @@ public sealed class EfCoreJobStore : IJobStore, IJobDashboardStore
         {
             _db.Jobs.Add(new JobEntryEntity
             {
-                Id = Guid.NewGuid(), TypeName = typeName, Payload = payload,
+                Id = JobId.New(), TypeName = typeName, Payload = payload,
                 Status = JobStatus.Pending, Attempts = 0, MaxAttempts = maxAttempts,
                 ScheduledAt = scheduledAt, CronExpression = cronExpression,
             });
@@ -153,7 +153,7 @@ public sealed class EfCoreJobStore : IJobStore, IJobDashboardStore
     public async Task RequeueAsync(JobId id, CancellationToken ct = default)
     {
         await _db.Jobs
-            .Where(j => j.Id == id.Value)
+            .Where(j => j.Id == id)
             .ExecuteUpdateAsync(s => s
                 .SetProperty(j => j.Status, JobStatus.Pending)
                 .SetProperty(j => j.Error, (string?)null)
@@ -163,7 +163,7 @@ public sealed class EfCoreJobStore : IJobStore, IJobDashboardStore
     public async Task DeleteAsync(JobId id, CancellationToken ct = default)
     {
         await _db.Jobs
-            .Where(j => j.Id == id.Value)
+            .Where(j => j.Id == id)
             .ExecuteDeleteAsync(ct).ConfigureAwait(false);
     }
 }

--- a/src/ZeroAlloc.Scheduling.EfCore/JobEntryEntity.cs
+++ b/src/ZeroAlloc.Scheduling.EfCore/JobEntryEntity.cs
@@ -1,8 +1,10 @@
+using ZeroAlloc.Scheduling;
+
 namespace ZeroAlloc.Scheduling.EfCore;
 
 public sealed class JobEntryEntity
 {
-    public Guid Id { get; set; }
+    public JobId Id { get; set; } = JobId.New();
     public required string TypeName { get; set; }
     public required byte[] Payload { get; set; }
     public JobStatus Status { get; set; }
@@ -17,7 +19,7 @@ public sealed class JobEntryEntity
 
     public JobEntry ToJobEntry() => new()
     {
-        Id = new JobId(Id), TypeName = TypeName, Payload = Payload, Status = Status,
+        Id = Id, TypeName = TypeName, Payload = Payload, Status = Status,
         Attempts = Attempts, MaxAttempts = MaxAttempts, ScheduledAt = ScheduledAt,
         StartedAt = StartedAt, CompletedAt = CompletedAt, NextRunAt = NextRunAt,
         CronExpression = CronExpression, Error = Error,

--- a/src/ZeroAlloc.Scheduling.EfCore/SchedulingDbContext.cs
+++ b/src/ZeroAlloc.Scheduling.EfCore/SchedulingDbContext.cs
@@ -1,5 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+using ZeroAlloc.ValueObjects.EfCore;
 
 namespace ZeroAlloc.Scheduling.EfCore;
 
@@ -23,6 +24,7 @@ public sealed class SchedulingDbContext : DbContext
         {
             e.ToTable("ScheduledJobs");
             e.HasKey(j => j.Id);
+            e.Property(j => j.Id).HasConversion<TypedIdValueConverter<JobId, Guid>>();
             e.Property(j => j.TypeName).HasMaxLength(256).IsRequired();
             e.Property(j => j.Status).HasConversion<int>();
             e.Property(j => j.Error).HasMaxLength(2000);

--- a/src/ZeroAlloc.Scheduling.EfCore/ZeroAlloc.Scheduling.EfCore.csproj
+++ b/src/ZeroAlloc.Scheduling.EfCore/ZeroAlloc.Scheduling.EfCore.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="9.0.3" />
+    <PackageReference Include="ZeroAlloc.ValueObjects.EfCore" Version="1.3.1" />
     <ProjectReference Include="..\ZeroAlloc.Scheduling\ZeroAlloc.Scheduling.csproj" />
     <PackageReference Include="ZeroAlloc.Outbox" Version="1.2.1" />
   </ItemGroup>

--- a/src/ZeroAlloc.Scheduling.Redis/RedisJobStore.cs
+++ b/src/ZeroAlloc.Scheduling.Redis/RedisJobStore.cs
@@ -11,7 +11,7 @@ public sealed class RedisJobStore : IJobStore, IJobDashboardStore
     public async ValueTask EnqueueAsync(string typeName, byte[] payload, DateTimeOffset scheduledAt,
         int maxAttempts, string? cronExpression, CancellationToken ct)
     {
-        var id = JobId.New().Value;
+        var id = JobId.New();
         var score = (double)scheduledAt.ToUnixTimeSeconds();
         var tran = _db.CreateTransaction();
         _ = tran.HashSetAsync($"job:{id}", BuildHash(id, typeName, payload, JobStatus.Pending, 0, maxAttempts, scheduledAt, cronExpression));
@@ -46,17 +46,17 @@ public sealed class RedisJobStore : IJobStore, IJobDashboardStore
         string? cronExpression, int maxAttempts, CancellationToken ct)
     {
         var tran = _db.CreateTransaction();
-        _ = tran.HashSetAsync($"job:{id.Value}", [new HashEntry("status", "Succeeded"), new HashEntry("completedAt", DateTimeOffset.UtcNow.ToUnixTimeSeconds())]);
-        _ = tran.SetRemoveAsync("jobs:running", id.Value.ToString());
-        _ = tran.SetAddAsync("jobs:succeeded", id.Value.ToString());
+        _ = tran.HashSetAsync($"job:{id}", [new HashEntry("status", "Succeeded"), new HashEntry("completedAt", DateTimeOffset.UtcNow.ToUnixTimeSeconds())]);
+        _ = tran.SetRemoveAsync("jobs:running", id.ToString());
+        _ = tran.SetAddAsync("jobs:succeeded", id.ToString());
 
         if (nextRunAt.HasValue)
         {
-            var typeName = (string?)(await _db.HashGetAsync($"job:{id.Value}", "typeName").ConfigureAwait(false));
-            var payload = (byte[]?)(await _db.HashGetAsync($"job:{id.Value}", "payload").ConfigureAwait(false));
+            var typeName = (string?)(await _db.HashGetAsync($"job:{id}", "typeName").ConfigureAwait(false));
+            var payload = (byte[]?)(await _db.HashGetAsync($"job:{id}", "payload").ConfigureAwait(false));
             if (typeName != null && payload != null)
             {
-                var nextId = JobId.New().Value;
+                var nextId = JobId.New();
                 _ = tran.HashSetAsync($"job:{nextId}", BuildHash(nextId, typeName, payload, JobStatus.Pending, 0, maxAttempts, nextRunAt.Value, cronExpression));
                 _ = tran.SortedSetAddAsync("jobs:pending", nextId.ToString(), (double)nextRunAt.Value.ToUnixTimeSeconds());
             }
@@ -68,19 +68,19 @@ public sealed class RedisJobStore : IJobStore, IJobDashboardStore
     {
         var score = (double)nextRetryAt.ToUnixTimeSeconds();
         var tran = _db.CreateTransaction();
-        _ = tran.HashSetAsync($"job:{id.Value}", [new HashEntry("status", "Failed"), new HashEntry("attempts", attempts), new HashEntry("scheduledAt", score)]);
-        _ = tran.SetRemoveAsync("jobs:running", id.Value.ToString());
-        _ = tran.SortedSetAddAsync("jobs:pending", id.Value.ToString(), score); // re-add to pending sorted set for retry
-        _ = tran.SetAddAsync("jobs:failed", id.Value.ToString());
+        _ = tran.HashSetAsync($"job:{id}", [new HashEntry("status", "Failed"), new HashEntry("attempts", attempts), new HashEntry("scheduledAt", score)]);
+        _ = tran.SetRemoveAsync("jobs:running", id.ToString());
+        _ = tran.SortedSetAddAsync("jobs:pending", id.ToString(), score); // re-add to pending sorted set for retry
+        _ = tran.SetAddAsync("jobs:failed", id.ToString());
         await tran.ExecuteAsync().ConfigureAwait(false);
     }
 
     public async ValueTask DeadLetterAsync(JobId id, string error, CancellationToken ct)
     {
         var tran = _db.CreateTransaction();
-        _ = tran.HashSetAsync($"job:{id.Value}", [new HashEntry("status", "DeadLetter"), new HashEntry("error", error), new HashEntry("completedAt", DateTimeOffset.UtcNow.ToUnixTimeSeconds())]);
-        _ = tran.SetRemoveAsync("jobs:running", id.Value.ToString());
-        _ = tran.SetAddAsync("jobs:deadletter", id.Value.ToString());
+        _ = tran.HashSetAsync($"job:{id}", [new HashEntry("status", "DeadLetter"), new HashEntry("error", error), new HashEntry("completedAt", DateTimeOffset.UtcNow.ToUnixTimeSeconds())]);
+        _ = tran.SetRemoveAsync("jobs:running", id.ToString());
+        _ = tran.SetAddAsync("jobs:deadletter", id.ToString());
         await tran.ExecuteAsync().ConfigureAwait(false);
     }
 
@@ -96,7 +96,7 @@ public sealed class RedisJobStore : IJobStore, IJobDashboardStore
 
         if (!exists)
         {
-            var id = JobId.New().Value;
+            var id = JobId.New();
             var score = (double)scheduledAt.ToUnixTimeSeconds();
             var tran = _db.CreateTransaction();
             _ = tran.HashSetAsync($"job:{id}", BuildHash(id, typeName, payload, JobStatus.Pending, 0, maxAttempts, scheduledAt, cronExpression));
@@ -175,25 +175,25 @@ public sealed class RedisJobStore : IJobStore, IJobDashboardStore
     {
         var score = (double)DateTimeOffset.UtcNow.ToUnixTimeSeconds();
         var tran = _db.CreateTransaction();
-        _ = tran.HashSetAsync($"job:{id.Value}", [new HashEntry("status", "Pending"), new HashEntry("error", RedisValue.EmptyString), new HashEntry("scheduledAt", score)]);
-        _ = tran.SetRemoveAsync("jobs:deadletter", id.Value.ToString());
-        _ = tran.SortedSetAddAsync("jobs:pending", id.Value.ToString(), score);
+        _ = tran.HashSetAsync($"job:{id}", [new HashEntry("status", "Pending"), new HashEntry("error", RedisValue.EmptyString), new HashEntry("scheduledAt", score)]);
+        _ = tran.SetRemoveAsync("jobs:deadletter", id.ToString());
+        _ = tran.SortedSetAddAsync("jobs:pending", id.ToString(), score);
         await tran.ExecuteAsync().ConfigureAwait(false);
     }
 
     public async Task DeleteAsync(JobId id, CancellationToken ct = default)
     {
         var tran = _db.CreateTransaction();
-        _ = tran.KeyDeleteAsync($"job:{id.Value}");
-        _ = tran.SortedSetRemoveAsync("jobs:pending", id.Value.ToString());
-        _ = tran.SetRemoveAsync("jobs:running", id.Value.ToString());
-        _ = tran.SetRemoveAsync("jobs:succeeded", id.Value.ToString());
-        _ = tran.SetRemoveAsync("jobs:failed", id.Value.ToString());
-        _ = tran.SetRemoveAsync("jobs:deadletter", id.Value.ToString());
+        _ = tran.KeyDeleteAsync($"job:{id}");
+        _ = tran.SortedSetRemoveAsync("jobs:pending", id.ToString());
+        _ = tran.SetRemoveAsync("jobs:running", id.ToString());
+        _ = tran.SetRemoveAsync("jobs:succeeded", id.ToString());
+        _ = tran.SetRemoveAsync("jobs:failed", id.ToString());
+        _ = tran.SetRemoveAsync("jobs:deadletter", id.ToString());
         await tran.ExecuteAsync().ConfigureAwait(false);
     }
 
-    private static HashEntry[] BuildHash(Guid id, string typeName, byte[] payload, JobStatus status,
+    private static HashEntry[] BuildHash(JobId id, string typeName, byte[] payload, JobStatus status,
         int attempts, int maxAttempts, DateTimeOffset scheduledAt, string? cronExpression)
     {
         var list = new List<HashEntry>
@@ -222,7 +222,7 @@ public sealed class RedisJobStore : IJobStore, IJobDashboardStore
     {
         return new JobEntry
         {
-            Id = new JobId(Guid.Parse((string)d["id"]!)),
+            Id = JobId.Parse((string)d["id"]!),
             TypeName = d["typeName"]!,
             Payload = (byte[])d["payload"]!,
             Status = Enum.Parse<JobStatus>((string)d["status"]!),

--- a/tests/ZeroAlloc.Scheduling.Dashboard.Tests/DashboardApiTests.cs
+++ b/tests/ZeroAlloc.Scheduling.Dashboard.Tests/DashboardApiTests.cs
@@ -52,7 +52,7 @@ public sealed class DashboardApiTests : IClassFixture<WebApplicationFactory<Prog
     public async Task RequeueNonExistentJob_Returns2xx()
     {
         // The endpoint is idempotent: missing IDs are silently ignored and 200 OK is returned.
-        var r = await _client.PostAsync($"/jobs/api/{Guid.NewGuid()}/requeue", null);
+        var r = await _client.PostAsync($"/jobs/api/{JobId.New()}/requeue", null);
         ((int)r.StatusCode).Should().BeInRange(200, 299);
     }
 
@@ -60,7 +60,7 @@ public sealed class DashboardApiTests : IClassFixture<WebApplicationFactory<Prog
     public async Task DeleteNonExistentJob_Returns2xx()
     {
         // The endpoint is idempotent: missing IDs are silently ignored and 200 OK is returned.
-        var r = await _client.DeleteAsync($"/jobs/api/{Guid.NewGuid()}");
+        var r = await _client.DeleteAsync($"/jobs/api/{JobId.New()}");
         ((int)r.StatusCode).Should().BeInRange(200, 299);
     }
 }

--- a/tests/ZeroAlloc.Scheduling.Dashboard.Tests/DashboardApiTests.cs
+++ b/tests/ZeroAlloc.Scheduling.Dashboard.Tests/DashboardApiTests.cs
@@ -1,15 +1,21 @@
 using System.Net;
 using System.Net.Http.Json;
 using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using ZeroAlloc.Scheduling.InMemory;
 
 namespace ZeroAlloc.Scheduling.Dashboard.Tests;
 
 public sealed class DashboardApiTests : IClassFixture<WebApplicationFactory<Program>>
 {
+    private readonly WebApplicationFactory<Program> _factory;
     private readonly HttpClient _client;
 
     public DashboardApiTests(WebApplicationFactory<Program> factory)
-        => _client = factory.CreateClient();
+    {
+        _factory = factory;
+        _client = factory.CreateClient();
+    }
 
     [Fact]
     public async Task GetSummary_Returns200()
@@ -62,5 +68,28 @@ public sealed class DashboardApiTests : IClassFixture<WebApplicationFactory<Prog
         // The endpoint is idempotent: missing IDs are silently ignored and 200 OK is returned.
         var r = await _client.DeleteAsync($"/jobs/api/{JobId.New()}");
         ((int)r.StatusCode).Should().BeInRange(200, 299);
+    }
+
+    [Fact]
+    public async Task DashboardRoute_BindsUlidStringToJobId()
+    {
+        // Reach into the same singleton InMemoryJobStore that the WebApplicationFactory built.
+        var store = (InMemoryJobStore)_factory.Services.GetRequiredService<IJobStore>();
+
+        // Seed a dead-lettered job so that requeue has a legal FSM transition (DeadLetter -> Pending).
+        await store.EnqueueAsync("BindingProbe", [], DateTimeOffset.UtcNow, 1, null, CancellationToken.None);
+        var running = await store.FetchPendingAsync(1, CancellationToken.None);
+        var id = running[0].Id;
+        await store.DeadLetterAsync(id, "seed", CancellationToken.None);
+
+        var ulidString = id.ToString(); // ULID base32, 26 chars
+        ulidString.Should().HaveLength(26);
+
+        var response = await _client.PostAsync($"/jobs/api/{ulidString}/requeue", content: null);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        // If the route bound the ULID into the same JobId value, the FSM transitioned to Pending.
+        var requeued = store.AllEntries.Single(e => e.Id == id);
+        requeued.Status.Should().Be(JobStatus.Pending);
     }
 }

--- a/tests/ZeroAlloc.Scheduling.EfCore.Tests/EfCoreJobStoreTests.cs
+++ b/tests/ZeroAlloc.Scheduling.EfCore.Tests/EfCoreJobStoreTests.cs
@@ -48,7 +48,7 @@ public sealed class EfCoreJobStoreTests : IDisposable
 
         await _store.MarkSucceededAsync(entry.Id, null, null, 3, _ct);
 
-        var updated = await _db.Jobs.FindAsync(entry.Id.Value);
+        var updated = await _db.Jobs.FindAsync(entry.Id);
         updated!.Status.Should().Be(JobStatus.Succeeded);
     }
 
@@ -60,7 +60,7 @@ public sealed class EfCoreJobStoreTests : IDisposable
 
         await _store.DeadLetterAsync(entry.Id, "oops", _ct);
 
-        var updated = await _db.Jobs.FindAsync(entry.Id.Value);
+        var updated = await _db.Jobs.FindAsync(entry.Id);
         updated!.Status.Should().Be(JobStatus.DeadLetter);
         updated.Error.Should().Be("oops");
     }

--- a/tests/ZeroAlloc.Scheduling.EfCore.Tests/TypedIdValueConverterTests.cs
+++ b/tests/ZeroAlloc.Scheduling.EfCore.Tests/TypedIdValueConverterTests.cs
@@ -1,0 +1,55 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+
+namespace ZeroAlloc.Scheduling.EfCore.Tests;
+
+/// <summary>
+/// Verifies that <see cref="JobEntryEntity.Id"/> survives a write/read round-trip
+/// through the <c>TypedIdValueConverter&lt;JobId, Guid&gt;</c> registered by
+/// <see cref="SchedulingDbContext"/>.
+/// </summary>
+public sealed class TypedIdValueConverterTests : IAsyncLifetime
+{
+    private SqliteConnection _conn = default!;
+    private SchedulingDbContext _db = default!;
+
+    public async Task InitializeAsync()
+    {
+        _conn = new SqliteConnection("DataSource=:memory:");
+        await _conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
+        var opts = new DbContextOptionsBuilder<SchedulingDbContext>()
+            .UseSqlite(_conn)
+            .Options;
+        _db = new SchedulingDbContext(opts);
+        await _db.Database.EnsureCreatedAsync(CancellationToken.None).ConfigureAwait(false);
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _db.DisposeAsync().ConfigureAwait(false);
+        await _conn.DisposeAsync().ConfigureAwait(false);
+    }
+
+    [Fact]
+    public async Task EntityRoundTrip_PreservesJobId()
+    {
+        var id = JobId.New();
+        _db.Jobs.Add(new JobEntryEntity
+        {
+            Id = id,
+            TypeName = "Test",
+            Payload = new byte[] { 0x01 },
+            Status = JobStatus.Pending,
+            MaxAttempts = 3,
+            ScheduledAt = DateTimeOffset.UtcNow,
+        });
+        await _db.SaveChangesAsync(CancellationToken.None);
+        _db.ChangeTracker.Clear();
+
+        var roundTripped = await _db.Jobs
+            .Where(e => e.Id == id)
+            .FirstAsync(CancellationToken.None);
+
+        roundTripped.Id.Should().Be(id);
+    }
+}

--- a/tests/ZeroAlloc.Scheduling.Resilience.Tests/SchedulingResilienceExtensionsTests.cs
+++ b/tests/ZeroAlloc.Scheduling.Resilience.Tests/SchedulingResilienceExtensionsTests.cs
@@ -37,7 +37,7 @@ public class SchedulingResilienceExtensionsTests
         var payload = System.Text.Encoding.UTF8.GetBytes("{}");
         var ctx = new JobContext
         {
-            JobId = new JobId(Guid.NewGuid()),
+            JobId = JobId.New(),
             Attempt = 1,
             ScheduledAt = DateTimeOffset.UtcNow,
             Services = new ServiceCollection().BuildServiceProvider(),


### PR DESCRIPTION
Closes #20.

## Summary
Closes the last raw-`Guid` boundaries in the Scheduling migration. The `JobId` typed wrapper now reaches the EF Core entity PK, the dashboard route surface (server + Blazor client + Razor component), the Redis serialization layer, and test fixtures.

## Breaking changes
- **Redis wire format**: hash keys change from 36-char hyphenated Guid strings to 26-char ULID base32 strings. **Live Redis-backed deployments must drain queues before upgrading.** Documented in `docs/stores.md` Redis section.
- **Dashboard URLs**: route format changes from `/api/{guid}/...` to `/api/{ulid}/...`. Bookmarked URLs return 404. Documented in `docs/dashboard.md`.
- **Blazor client API**: `JobsDashboardClient.RequeueAsync(Guid, ...)` and `DeleteAsync(Guid, ...)` now take `JobId`. Source-break for direct callers; transitive users via DI are unaffected. The Razor `JobsDashboard.razor` component was updated in lockstep.

## Other changes
- `JobEntryEntity.Id`: `Guid` → `JobId`, with `TypedIdValueConverter<JobId, Guid>` registered inline at the entity-config site in `SchedulingDbContext.OnModelCreating`. Column type stays `uniqueidentifier`/`BLOB(16)`; no EF migration.
- `EfCoreJobStore`: 3 `Guid.NewGuid()` → `JobId.New()`, 3 `FindAsync(id.Value)` → `FindAsync(id)`, 2 `Where(j => j.Id == id.Value)` → `Where(j => j.Id == id)`, 1 `new JobId(Id)` projection wrapper dropped.
- `RedisJobStore`: every hash-key serialization site (`EnqueueAsync`, `MarkSucceededAsync`, `MarkFailedAsync`, `DeadLetterAsync`, `UpsertRecurringAsync`, `RequeueAsync`, `DeleteAsync`, `BuildHash`, `BuildJobEntry`) updated. `id.Value.ToString()` → `id.ToString()`; `new JobId(Guid.Parse(...))` → `JobId.Parse(...)`.
- `ZeroAlloc.ValueObjects.EfCore 1.3.1` package reference added to `ZeroAlloc.Scheduling.EfCore`. EF Core was already at 9.0.3; no version bump needed.
- Test fixtures updated: 5 `Guid.NewGuid()` callsites → `JobId.New()` across DashboardApiTests, SchedulingResilienceExtensionsTests, EfCoreJobStoreTests.
- 2 new tests: `TypedIdValueConverterTests.EntityRoundTrip_PreservesJobId` (EF round-trip), `DashboardRoute_BindsUlidStringToJobId` (route binding).
- Redis hash-key round-trip test skipped — no `ZeroAlloc.Scheduling.Redis.Tests` project exists; out of scope to scaffold one for this PR. Wire-format change covered by the BREAKING CHANGE note + docs.

## Test plan
- [x] EF round-trip test passes
- [x] Dashboard ULID route binding test passes (POST `/jobs/api/{ulid}/requeue` → status flip Pending)
- [x] All existing tests green: 71/71 (baseline 69 + 2 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)