### PR TITLE
ci(release): publish Scheduling bridge packages to NuGet

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -51,7 +51,8 @@ jobs:
           for pkg in ZeroAlloc.Scheduling ZeroAlloc.Scheduling.Generator ZeroAlloc.Scheduling.EfCore \
                      ZeroAlloc.Scheduling.InMemory ZeroAlloc.Scheduling.Redis \
                      ZeroAlloc.Scheduling.Dashboard ZeroAlloc.Scheduling.Dashboard.Blazor \
-                     ZeroAlloc.Scheduling.Mediator; do
+                     ZeroAlloc.Scheduling.Mediator ZeroAlloc.Scheduling.Resilience \
+                     ZeroAlloc.Scheduling.Telemetry; do
             dotnet pack src/$pkg/$pkg.csproj -c Release \
               -p:PackageVersion=${{ needs.release-please.outputs.version }} --no-build -o ./artifacts
           done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,8 @@ jobs:
           for pkg in ZeroAlloc.Scheduling ZeroAlloc.Scheduling.Generator ZeroAlloc.Scheduling.EfCore \
                      ZeroAlloc.Scheduling.InMemory ZeroAlloc.Scheduling.Redis \
                      ZeroAlloc.Scheduling.Dashboard ZeroAlloc.Scheduling.Dashboard.Blazor \
-                     ZeroAlloc.Scheduling.Mediator; do
+                     ZeroAlloc.Scheduling.Mediator ZeroAlloc.Scheduling.Resilience \
+                     ZeroAlloc.Scheduling.Telemetry; do
             dotnet pack src/$pkg/$pkg.csproj --no-build -c Release \
               -p:PackageVersion=${{ steps.version.outputs.version }} -o ./artifacts
           done


### PR DESCRIPTION
## Summary
The release workflows previously only packed the core Scheduling packages and the Mediator bridge. The two remaining bridges — Resilience and Telemetry — were never published to NuGet, making them effectively only usable as ProjectReferences.

This PR extends both release workflows to pack and push both bridges alongside the existing list. Same fix pattern as ZeroAlloc.Mediator#54.

## Affected packages (now publishable)
- ZeroAlloc.Scheduling.Resilience
- ZeroAlloc.Scheduling.Telemetry

## Test plan
- [x] dotnet pack succeeds for both bridges locally
- [ ] Next release-please cycle publishes all 10 packages (verify post-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)