### PR TITLE
chore(release): promote ZeroAlloc.Scheduling to 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.0.0
+
+Stability milestone — public API of `ZeroAlloc.Scheduling` is now considered stable. Bundles PR #33 (CI: publish bridge packages — Resilience and Telemetry — to NuGet). This release marks the transition out of pre-1.0 SemVer.
+
 ## [0.3.0](https://github.com/ZeroAlloc-Net/ZeroAlloc.Scheduling/compare/v0.2.1...v0.3.0) (2026-04-28)
 
 


### PR DESCRIPTION
## Summary
Promote the package to the 1.0 stability milestone.

Part of an ecosystem-wide campaign promoting all sub-1.0 ZeroAlloc packages to 1.0.0 now that the integration matrix is complete.

## Mechanism
The merge commit footer `Release-As: 1.0.0` instructs release-please to release as 1.0.0.

Release-As: 1.0.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)