### PR TITLE
ci(release-please): add 'deps' to changelog-sections

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -11,6 +11,7 @@
         { "type": "refactor", "section": "Code Refactoring" },
         { "type": "docs",     "section": "Documentation"    },
         { "type": "test",     "section": "Tests"            },
+        { "type": "deps",     "section": "Dependencies"     },
         { "type": "build",    "section": "Build System"     },
         { "type": "ci",       "section": "CI"               },
         { "type": "chore",    "section": "Chores"           },


### PR DESCRIPTION
## Summary
Add `{ "type": "deps", "section": "Dependencies" }` to `release-please-config.json`'s `changelog-sections`.

## Why
Conventional Commit type `deps` was previously unrecognized and silently treated as `chore` (hidden). Dependency-bump commits landed on main but did NOT appear in release-please's auto-generated CHANGELOG as a result.

After this PR merges, future `deps:` commits will appear in CHANGELOG under a "Dependencies" section.

## Background
This is part of an ecosystem-wide ci-config consistency campaign — same fix shipped to ZeroAlloc.Saga as PR #7 after we noticed a Mediator-3.0 bump silently dropped from the auto-generated changelog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
