### PR TITLE
feat: bundle source generator into ZeroAlloc.Scheduling package

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,16 +10,14 @@ ZeroAlloc.Scheduling is a source-generated background job scheduler for .NET 8 a
 
 ## Install
 
+The source generator is bundled into the main package — a single `PackageReference` is all you need:
+
 ```bash
 dotnet add package ZeroAlloc.Scheduling
 dotnet add package ZeroAlloc.Scheduling.InMemory   # or EfCore / Redis
 ```
 
-The generator package must be added as an analyzer:
-
-```xml
-<PackageReference Include="ZeroAlloc.Scheduling.Generator" Version="*" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
-```
+> The standalone `ZeroAlloc.Scheduling.Generator` package is still published for backwards compatibility with existing direct PackageReferences, but new consumers should reference only `ZeroAlloc.Scheduling`.
 
 ## Example
 

--- a/src/ZeroAlloc.Scheduling/ZeroAlloc.Scheduling.csproj
+++ b/src/ZeroAlloc.Scheduling/ZeroAlloc.Scheduling.csproj
@@ -29,4 +29,19 @@
   <ItemGroup>
     <InternalsVisibleTo Include="ZeroAlloc.Scheduling.Tests" />
   </ItemGroup>
+
+  <!--
+    Bundle the source generator into the NuGet package so consumers get it by
+    referencing only ZeroAlloc.Scheduling. The standalone
+    ZeroAlloc.Scheduling.Generator package is still published for backwards
+    compatibility, but new consumers should reference the main package only.
+  -->
+  <Target Name="IncludeGeneratorInPackage" BeforeTargets="_GetPackageFiles">
+    <ItemGroup>
+      <None Include="$(MSBuildThisFileDirectory)..\ZeroAlloc.Scheduling.Generator\bin\$(Configuration)\netstandard2.0\ZeroAlloc.Scheduling.Generator.dll"
+            Pack="true"
+            PackagePath="analyzers/dotnet/cs"
+            Visible="false" />
+    </ItemGroup>
+  </Target>
 </Project>


### PR DESCRIPTION
## Summary
Until now consumers had to install both `ZeroAlloc.Scheduling` and `ZeroAlloc.Scheduling.Generator` (with the right `OutputItemType` / `PrivateAssets` flags) to get a working setup. Bundling the generator DLL inside the main library's NuGet package under `analyzers/dotnet/cs/` means **a single `PackageReference` is now enough**.

`ZeroAlloc.Scheduling.Generator` continues to publish as a standalone package for backwards compatibility with existing direct `PackageReference`s. New consumers should reference only `ZeroAlloc.Scheduling`.

## What changes
- Add `IncludeGeneratorInPackage` MSBuild target that packs the generator DLL under `analyzers/dotnet/cs/` in the main library's nupkg

## Test plan
- [ ] CI green
- [ ] `dotnet pack` produces `ZeroAlloc.Scheduling.nupkg` containing the generator DLL at `analyzers/dotnet/cs/`
- [ ] In a fresh project with only `<PackageReference Include="ZeroAlloc.Scheduling">`, a `[Job]`-attributed class produces generated code
- [ ] Existing setups with both packages referenced continue to work (Roslyn dedupes same-version analyzers)

Related: ZeroAlloc-Net/ZeroAlloc.Rest#67

🤖 Generated with [Claude Code](https://claude.com/claude-code)