### PR TITLE
feat: lock public API surface (PublicApiAnalyzers + api-compat gate)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,3 +82,9 @@ jobs:
 
       - name: Run AOT binary
         run: ./aot-out/ZeroAlloc.Scheduling.AotSmoke
+
+  api-compat:
+    uses: ZeroAlloc-Net/.github/.github/workflows/api-compat.yml@main
+    with:
+      package-id: ZeroAlloc.Scheduling
+      csproj-path: src/ZeroAlloc.Scheduling/ZeroAlloc.Scheduling.csproj

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,6 +4,10 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>latest</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <!-- Lock the public API surface: RS0016 (undeclared symbol) and RS0017
+         (declared-but-missing symbol) are always errors so any change to the
+         public API must go through PublicAPI.{Shipped,Unshipped}.txt. -->
+    <WarningsAsErrors>$(WarningsAsErrors);RS0016;RS0017</WarningsAsErrors>
 
     <Authors>Marcel Roozekrans</Authors>
     <Company>Marcel Roozekrans</Company>

--- a/src/ZeroAlloc.Scheduling/PublicAPI.Shipped.txt
+++ b/src/ZeroAlloc.Scheduling/PublicAPI.Shipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/ZeroAlloc.Scheduling/PublicAPI.Unshipped.txt
+++ b/src/ZeroAlloc.Scheduling/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/ZeroAlloc.Scheduling/PublicAPI.Unshipped.txt
+++ b/src/ZeroAlloc.Scheduling/PublicAPI.Unshipped.txt
@@ -1,1 +1,162 @@
 #nullable enable
+ZeroAlloc.Scheduling.DefaultJobSerializer
+ZeroAlloc.Scheduling.DefaultJobSerializer.DefaultJobSerializer() -> void
+ZeroAlloc.Scheduling.DefaultJobSerializer.Deserialize<T>(byte[]! payload) -> T
+ZeroAlloc.Scheduling.DefaultJobSerializer.Serialize<T>(T job) -> byte[]!
+ZeroAlloc.Scheduling.DispatchingJobSerializer
+ZeroAlloc.Scheduling.DispatchingJobSerializer.Deserialize<T>(byte[]! payload) -> T
+ZeroAlloc.Scheduling.DispatchingJobSerializer.DispatchingJobSerializer(ZeroAlloc.Serialisation.ISerializerDispatcher! dispatcher) -> void
+ZeroAlloc.Scheduling.DispatchingJobSerializer.Serialize<T>(T job) -> byte[]!
+ZeroAlloc.Scheduling.Every
+ZeroAlloc.Scheduling.Every.Day = 7 -> ZeroAlloc.Scheduling.Every
+ZeroAlloc.Scheduling.Every.FifteenMinutes = 2 -> ZeroAlloc.Scheduling.Every
+ZeroAlloc.Scheduling.Every.FiveMinutes = 1 -> ZeroAlloc.Scheduling.Every
+ZeroAlloc.Scheduling.Every.Hour = 4 -> ZeroAlloc.Scheduling.Every
+ZeroAlloc.Scheduling.Every.Minute = 0 -> ZeroAlloc.Scheduling.Every
+ZeroAlloc.Scheduling.Every.SixHours = 5 -> ZeroAlloc.Scheduling.Every
+ZeroAlloc.Scheduling.Every.ThirtyMinutes = 3 -> ZeroAlloc.Scheduling.Every
+ZeroAlloc.Scheduling.Every.TwelveHours = 6 -> ZeroAlloc.Scheduling.Every
+ZeroAlloc.Scheduling.Every.Week = 8 -> ZeroAlloc.Scheduling.Every
+ZeroAlloc.Scheduling.EveryToCron
+ZeroAlloc.Scheduling.IJob
+ZeroAlloc.Scheduling.IJob.ExecuteAsync(ZeroAlloc.Scheduling.JobContext! ctx, System.Threading.CancellationToken ct) -> System.Threading.Tasks.ValueTask
+ZeroAlloc.Scheduling.IJobDashboardStore
+ZeroAlloc.Scheduling.IJobDashboardStore.DeleteAsync(ZeroAlloc.Scheduling.JobId id, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+ZeroAlloc.Scheduling.IJobDashboardStore.GetRecurringAsync(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<ZeroAlloc.Scheduling.JobEntry!>!>!
+ZeroAlloc.Scheduling.IJobDashboardStore.GetSummaryAsync(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<ZeroAlloc.Scheduling.JobSummary!>!
+ZeroAlloc.Scheduling.IJobDashboardStore.QueryByStatusAsync(ZeroAlloc.Scheduling.JobStatus[]! statuses, int page = 1, int pageSize = 50, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<ZeroAlloc.Scheduling.JobEntry!>!>!
+ZeroAlloc.Scheduling.IJobDashboardStore.RequeueAsync(ZeroAlloc.Scheduling.JobId id, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+ZeroAlloc.Scheduling.IJobSerializer
+ZeroAlloc.Scheduling.IJobSerializer.Deserialize<T>(byte[]! payload) -> T
+ZeroAlloc.Scheduling.IJobSerializer.Serialize<T>(T job) -> byte[]!
+ZeroAlloc.Scheduling.IJobStore
+ZeroAlloc.Scheduling.IJobStore.DeadLetterAsync(ZeroAlloc.Scheduling.JobId id, string! error, System.Threading.CancellationToken ct) -> System.Threading.Tasks.ValueTask
+ZeroAlloc.Scheduling.IJobStore.EnqueueAsync(string! typeName, byte[]! payload, System.DateTimeOffset scheduledAt, int maxAttempts, string? cronExpression, System.Threading.CancellationToken ct) -> System.Threading.Tasks.ValueTask
+ZeroAlloc.Scheduling.IJobStore.FetchPendingAsync(int batchSize, System.Threading.CancellationToken ct) -> System.Threading.Tasks.ValueTask<System.Collections.Generic.IReadOnlyList<ZeroAlloc.Scheduling.JobEntry!>!>
+ZeroAlloc.Scheduling.IJobStore.MarkFailedAsync(ZeroAlloc.Scheduling.JobId id, int attempts, System.DateTimeOffset nextRetryAt, System.Threading.CancellationToken ct) -> System.Threading.Tasks.ValueTask
+ZeroAlloc.Scheduling.IJobStore.MarkSucceededAsync(ZeroAlloc.Scheduling.JobId id, System.DateTimeOffset? nextRunAt, string? cronExpression, int maxAttempts, System.Threading.CancellationToken ct) -> System.Threading.Tasks.ValueTask
+ZeroAlloc.Scheduling.IJobStore.UpsertRecurringAsync(string! typeName, byte[]! payload, System.DateTimeOffset scheduledAt, string? cronExpression, int maxAttempts, System.Threading.CancellationToken ct) -> System.Threading.Tasks.ValueTask
+ZeroAlloc.Scheduling.IJobTypeExecutor
+ZeroAlloc.Scheduling.IJobTypeExecutor.ExecuteAsync(byte[]! payload, ZeroAlloc.Scheduling.JobContext! ctx, System.Threading.CancellationToken ct) -> System.Threading.Tasks.ValueTask
+ZeroAlloc.Scheduling.IJobTypeExecutor.MaxAttempts.get -> int
+ZeroAlloc.Scheduling.IJobTypeExecutor.TypeName.get -> string!
+ZeroAlloc.Scheduling.IScheduler
+ZeroAlloc.Scheduling.IScheduler.EnqueueAsync<TJob>(TJob job, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask
+ZeroAlloc.Scheduling.IScheduler.EnqueueAsync<TJob>(TJob job, System.TimeSpan delay, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask
+ZeroAlloc.Scheduling.ISchedulingBuilder
+ZeroAlloc.Scheduling.ISchedulingBuilder.Services.get -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
+ZeroAlloc.Scheduling.JobAttribute
+ZeroAlloc.Scheduling.JobAttribute.Cron.get -> string?
+ZeroAlloc.Scheduling.JobAttribute.Cron.set -> void
+ZeroAlloc.Scheduling.JobAttribute.Every.get -> ZeroAlloc.Scheduling.Every
+ZeroAlloc.Scheduling.JobAttribute.Every.set -> void
+ZeroAlloc.Scheduling.JobAttribute.JobAttribute() -> void
+ZeroAlloc.Scheduling.JobAttribute.MaxAttempts.get -> int
+ZeroAlloc.Scheduling.JobAttribute.MaxAttempts.set -> void
+ZeroAlloc.Scheduling.JobContext
+ZeroAlloc.Scheduling.JobContext.Attempt.get -> int
+ZeroAlloc.Scheduling.JobContext.Attempt.init -> void
+ZeroAlloc.Scheduling.JobContext.JobContext() -> void
+ZeroAlloc.Scheduling.JobContext.JobId.get -> ZeroAlloc.Scheduling.JobId
+ZeroAlloc.Scheduling.JobContext.JobId.init -> void
+ZeroAlloc.Scheduling.JobContext.ScheduledAt.get -> System.DateTimeOffset
+ZeroAlloc.Scheduling.JobContext.ScheduledAt.init -> void
+ZeroAlloc.Scheduling.JobContext.Services.get -> System.IServiceProvider!
+ZeroAlloc.Scheduling.JobContext.Services.init -> void
+ZeroAlloc.Scheduling.JobEntry
+ZeroAlloc.Scheduling.JobEntry.Attempts.get -> int
+ZeroAlloc.Scheduling.JobEntry.Attempts.init -> void
+ZeroAlloc.Scheduling.JobEntry.CompletedAt.get -> System.DateTimeOffset?
+ZeroAlloc.Scheduling.JobEntry.CompletedAt.init -> void
+ZeroAlloc.Scheduling.JobEntry.CronExpression.get -> string?
+ZeroAlloc.Scheduling.JobEntry.CronExpression.init -> void
+ZeroAlloc.Scheduling.JobEntry.Error.get -> string?
+ZeroAlloc.Scheduling.JobEntry.Error.init -> void
+ZeroAlloc.Scheduling.JobEntry.Id.get -> ZeroAlloc.Scheduling.JobId
+ZeroAlloc.Scheduling.JobEntry.Id.init -> void
+ZeroAlloc.Scheduling.JobEntry.JobEntry() -> void
+ZeroAlloc.Scheduling.JobEntry.MaxAttempts.get -> int
+ZeroAlloc.Scheduling.JobEntry.MaxAttempts.init -> void
+ZeroAlloc.Scheduling.JobEntry.NextRunAt.get -> System.DateTimeOffset?
+ZeroAlloc.Scheduling.JobEntry.NextRunAt.init -> void
+ZeroAlloc.Scheduling.JobEntry.Payload.get -> byte[]!
+ZeroAlloc.Scheduling.JobEntry.Payload.init -> void
+ZeroAlloc.Scheduling.JobEntry.ScheduledAt.get -> System.DateTimeOffset
+ZeroAlloc.Scheduling.JobEntry.ScheduledAt.init -> void
+ZeroAlloc.Scheduling.JobEntry.StartedAt.get -> System.DateTimeOffset?
+ZeroAlloc.Scheduling.JobEntry.StartedAt.init -> void
+ZeroAlloc.Scheduling.JobEntry.Status.get -> ZeroAlloc.Scheduling.JobStatus
+ZeroAlloc.Scheduling.JobEntry.Status.init -> void
+ZeroAlloc.Scheduling.JobEntry.TypeName.get -> string!
+ZeroAlloc.Scheduling.JobEntry.TypeName.init -> void
+ZeroAlloc.Scheduling.JobId
+ZeroAlloc.Scheduling.JobId.CompareTo(ZeroAlloc.Scheduling.JobId other) -> int
+ZeroAlloc.Scheduling.JobId.Equals(ZeroAlloc.Scheduling.JobId other) -> bool
+ZeroAlloc.Scheduling.JobId.JobId() -> void
+ZeroAlloc.Scheduling.JobId.JobId(System.Guid value) -> void
+ZeroAlloc.Scheduling.JobId.Value.get -> System.Guid
+ZeroAlloc.Scheduling.JobStatus
+ZeroAlloc.Scheduling.JobStatus.DeadLetter = 4 -> ZeroAlloc.Scheduling.JobStatus
+ZeroAlloc.Scheduling.JobStatus.Failed = 3 -> ZeroAlloc.Scheduling.JobStatus
+ZeroAlloc.Scheduling.JobStatus.Pending = 0 -> ZeroAlloc.Scheduling.JobStatus
+ZeroAlloc.Scheduling.JobStatus.Running = 1 -> ZeroAlloc.Scheduling.JobStatus
+ZeroAlloc.Scheduling.JobStatus.Succeeded = 2 -> ZeroAlloc.Scheduling.JobStatus
+ZeroAlloc.Scheduling.JobStatusFsm
+ZeroAlloc.Scheduling.JobStatusFsm.Current.get -> ZeroAlloc.Scheduling.JobStatus
+ZeroAlloc.Scheduling.JobStatusFsm.JobStatusFsm(ZeroAlloc.Scheduling.JobStatus current) -> void
+ZeroAlloc.Scheduling.JobStatusFsm.TryFire(ZeroAlloc.Scheduling.JobTrigger trigger) -> bool
+ZeroAlloc.Scheduling.JobSummary
+ZeroAlloc.Scheduling.JobSummary.<Clone>$() -> ZeroAlloc.Scheduling.JobSummary!
+ZeroAlloc.Scheduling.JobSummary.DeadLetter.get -> int
+ZeroAlloc.Scheduling.JobSummary.DeadLetter.init -> void
+ZeroAlloc.Scheduling.JobSummary.Deconstruct(out int Pending, out int Running, out int Succeeded, out int Failed, out int DeadLetter) -> void
+ZeroAlloc.Scheduling.JobSummary.Equals(ZeroAlloc.Scheduling.JobSummary? other) -> bool
+ZeroAlloc.Scheduling.JobSummary.Failed.get -> int
+ZeroAlloc.Scheduling.JobSummary.Failed.init -> void
+ZeroAlloc.Scheduling.JobSummary.JobSummary(int Pending, int Running, int Succeeded, int Failed, int DeadLetter) -> void
+ZeroAlloc.Scheduling.JobSummary.Pending.get -> int
+ZeroAlloc.Scheduling.JobSummary.Pending.init -> void
+ZeroAlloc.Scheduling.JobSummary.Running.get -> int
+ZeroAlloc.Scheduling.JobSummary.Running.init -> void
+ZeroAlloc.Scheduling.JobSummary.Succeeded.get -> int
+ZeroAlloc.Scheduling.JobSummary.Succeeded.init -> void
+ZeroAlloc.Scheduling.JobTrigger
+ZeroAlloc.Scheduling.JobTrigger.Claim = 0 -> ZeroAlloc.Scheduling.JobTrigger
+ZeroAlloc.Scheduling.JobTrigger.DeadLetter = 3 -> ZeroAlloc.Scheduling.JobTrigger
+ZeroAlloc.Scheduling.JobTrigger.Fail = 2 -> ZeroAlloc.Scheduling.JobTrigger
+ZeroAlloc.Scheduling.JobTrigger.Requeue = 4 -> ZeroAlloc.Scheduling.JobTrigger
+ZeroAlloc.Scheduling.JobTrigger.Succeed = 1 -> ZeroAlloc.Scheduling.JobTrigger
+ZeroAlloc.Scheduling.SchedulingOptions
+ZeroAlloc.Scheduling.SchedulingOptions.BatchSize.get -> int
+ZeroAlloc.Scheduling.SchedulingOptions.BatchSize.set -> void
+ZeroAlloc.Scheduling.SchedulingOptions.DefaultMaxAttempts.get -> int
+ZeroAlloc.Scheduling.SchedulingOptions.DefaultMaxAttempts.set -> void
+ZeroAlloc.Scheduling.SchedulingOptions.PollingInterval.get -> System.TimeSpan
+ZeroAlloc.Scheduling.SchedulingOptions.PollingInterval.set -> void
+ZeroAlloc.Scheduling.SchedulingOptions.RetryBaseDelay.get -> System.TimeSpan
+ZeroAlloc.Scheduling.SchedulingOptions.RetryBaseDelay.set -> void
+ZeroAlloc.Scheduling.SchedulingOptions.SchedulingOptions() -> void
+ZeroAlloc.Scheduling.SchedulingServiceCollectionExtensions
+ZeroAlloc.Scheduling.SchedulingWorkerService
+ZeroAlloc.Scheduling.SchedulingWorkerService.SchedulingWorkerService(Microsoft.Extensions.DependencyInjection.IServiceScopeFactory! scopeFactory, Microsoft.Extensions.Options.IOptionsMonitor<ZeroAlloc.Scheduling.SchedulingOptions!>! options, Microsoft.Extensions.Logging.ILogger<ZeroAlloc.Scheduling.SchedulingWorkerService!>! logger, System.Collections.Generic.IEnumerable<ZeroAlloc.Scheduling.IJobTypeExecutor!>! executors) -> void
+override ZeroAlloc.Scheduling.JobId.GetHashCode() -> int
+override ZeroAlloc.Scheduling.JobId.ToString() -> string!
+override ZeroAlloc.Scheduling.JobSummary.Equals(object? obj) -> bool
+override ZeroAlloc.Scheduling.JobSummary.GetHashCode() -> int
+override ZeroAlloc.Scheduling.JobSummary.ToString() -> string!
+static ZeroAlloc.Scheduling.EveryToCron.Convert(ZeroAlloc.Scheduling.Every every) -> string!
+static ZeroAlloc.Scheduling.JobId.New() -> ZeroAlloc.Scheduling.JobId
+static ZeroAlloc.Scheduling.JobId.Parse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider) -> ZeroAlloc.Scheduling.JobId
+static ZeroAlloc.Scheduling.JobId.Parse(string! s, System.IFormatProvider? provider = null) -> ZeroAlloc.Scheduling.JobId
+static ZeroAlloc.Scheduling.JobId.TryParse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider, out ZeroAlloc.Scheduling.JobId result) -> bool
+static ZeroAlloc.Scheduling.JobId.TryParse(string? s, System.IFormatProvider? provider, out ZeroAlloc.Scheduling.JobId result) -> bool
+static ZeroAlloc.Scheduling.JobId.operator !=(ZeroAlloc.Scheduling.JobId left, ZeroAlloc.Scheduling.JobId right) -> bool
+static ZeroAlloc.Scheduling.JobId.operator <(ZeroAlloc.Scheduling.JobId left, ZeroAlloc.Scheduling.JobId right) -> bool
+static ZeroAlloc.Scheduling.JobId.operator <=(ZeroAlloc.Scheduling.JobId left, ZeroAlloc.Scheduling.JobId right) -> bool
+static ZeroAlloc.Scheduling.JobId.operator ==(ZeroAlloc.Scheduling.JobId left, ZeroAlloc.Scheduling.JobId right) -> bool
+static ZeroAlloc.Scheduling.JobId.operator >(ZeroAlloc.Scheduling.JobId left, ZeroAlloc.Scheduling.JobId right) -> bool
+static ZeroAlloc.Scheduling.JobId.operator >=(ZeroAlloc.Scheduling.JobId left, ZeroAlloc.Scheduling.JobId right) -> bool
+static ZeroAlloc.Scheduling.JobSummary.operator !=(ZeroAlloc.Scheduling.JobSummary? left, ZeroAlloc.Scheduling.JobSummary? right) -> bool
+static ZeroAlloc.Scheduling.JobSummary.operator ==(ZeroAlloc.Scheduling.JobSummary? left, ZeroAlloc.Scheduling.JobSummary? right) -> bool
+static ZeroAlloc.Scheduling.SchedulingServiceCollectionExtensions.AddScheduling(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services, System.Action<ZeroAlloc.Scheduling.SchedulingOptions!>? configure = null) -> ZeroAlloc.Scheduling.ISchedulingBuilder!
+~override ZeroAlloc.Scheduling.JobId.Equals(object obj) -> bool

--- a/src/ZeroAlloc.Scheduling/ZeroAlloc.Scheduling.csproj
+++ b/src/ZeroAlloc.Scheduling/ZeroAlloc.Scheduling.csproj
@@ -6,6 +6,18 @@
     <Description>Source-generated zero-allocation background job scheduling for .NET.</Description>
     <Version>0.0.0-local</Version>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+    <!--
+      RS0026: IScheduler.EnqueueAsync<TJob> ships two overloads that both
+              carry an optional CancellationToken parameter. The second
+              overload adds a required TimeSpan delay so consumers cannot
+              invoke it ambiguously, but the analyzer still flags the
+              pattern. Suppressing here keeps the existing public surface.
+      RS0027: Emitted by the ZeroAlloc.ValueObjects TypedId source generator
+              for JobId.Parse — the generator emits two Parse overloads
+              where the optional-parameter variant is not the longest. We
+              cannot edit generator output, so suppress at the consumer.
+    -->
+    <NoWarn>$(NoWarn);RS0026;RS0027</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.1" />

--- a/src/ZeroAlloc.Scheduling/ZeroAlloc.Scheduling.csproj
+++ b/src/ZeroAlloc.Scheduling/ZeroAlloc.Scheduling.csproj
@@ -30,6 +30,17 @@
     <InternalsVisibleTo Include="ZeroAlloc.Scheduling.Tests" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="4.14.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <AdditionalFiles Include="PublicAPI.Shipped.txt" />
+    <AdditionalFiles Include="PublicAPI.Unshipped.txt" />
+  </ItemGroup>
+
   <!--
     Bundle the source generator into the NuGet package so consumers get it by
     referencing only ZeroAlloc.Scheduling. The standalone


### PR DESCRIPTION
## Summary

Adds the public-API gating pattern to **ZeroAlloc.Scheduling** (Phase B fan-out). Only the runtime contract `src/ZeroAlloc.Scheduling/ZeroAlloc.Scheduling.csproj` is gated; sub-packages (`.InMemory`, `.EfCore`, `.Redis`, `.Generator`, `.Telemetry`, `.Resilience`, `.Mediator`, `.Dashboard*`) can adopt later.

- Adds `Microsoft.CodeAnalysis.PublicApiAnalyzers` 4.14.0 + `PublicAPI.Shipped.txt` / `PublicAPI.Unshipped.txt` to the runtime csproj.
- Captures the current 161-symbol baseline into `PublicAPI.Unshipped.txt` (union across `net8.0`/`net9.0`/`net10.0` — identical per TFM).
- Promotes RS0016/RS0017 to errors via `Directory.Build.props`. Suppresses RS0026 (`IScheduler.EnqueueAsync<TJob>` overload pattern) and RS0027 (emitted by ZeroAlloc.ValueObjects' TypedId generator for `JobId.Parse`) in the runtime csproj `<NoWarn>` only — both are pre-existing patterns we cannot change without breaking consumers / generator output.
- Wires the shared `ZeroAlloc-Net/.github` `api-compat.yml` reusable workflow into CI.

## Sibling reference PRs

This is the Scheduling instance of a cross-repo Phase B fan-out:

- ZeroAlloc.Authorization#5
- ZeroAlloc.AsyncEvents#47
- ZeroAlloc.Notify#43
- ZeroAlloc.Telemetry#19
- ZeroAlloc.ValueObjects#38
- ZeroAlloc.Outbox#44

## Notes / surprises

- Global `TreatWarningsAsErrors=true` is already on in `Directory.Build.props`. As predicted, the first baseline build short-circuited on the first RS0016 per-TFM, so the baseline-generation build used `-p:TreatWarningsAsErrors=false`. After populating `Unshipped.txt`, the default TWAE build is clean again (with the RS0026/RS0027 suppressions noted above).
- RS0027 is the same TypedId-generator artefact Outbox just hit on its identical fan-out PR — kept the suppression isolated to the runtime csproj so it doesn't mask future regressions in other projects.

## Test plan

- [x] `dotnet build src/ZeroAlloc.Scheduling/ZeroAlloc.Scheduling.csproj -c Release` clean (0 warnings, 0 errors)
- [x] Solution-wide `dotnet build -c Release` clean (0 warnings, 0 errors)
- [x] `dotnet test --no-build -c Release` — all 71 tests pass (Tests 33, EfCore 13, Dashboard 10, Generator 6, Telemetry 5, Resilience 4)
- [ ] CI green on push (api-compat job included)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)