### PR TITLE
fix(release-please): drop pre-major flags (package is post-1.0)

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,8 +2,6 @@
   "packages": {
     ".": {
       "release-type": "simple",
-      "bump-minor-pre-major": true,
-      "bump-patch-for-minor-pre-major": true,
       "changelog-sections": [
         { "type": "feat",     "section": "Features"         },
         { "type": "fix",      "section": "Bug Fixes"        },


### PR DESCRIPTION
## Summary

`release-please-config.json` had `bump-minor-pre-major: true` and `bump-patch-for-minor-pre-major: true` set. Both flags only apply while a package is on the 0.x line — this package is at **1.1.0**, so they are no-ops today and a silent SemVer hazard if the package were ever rolled back to 0.x.

Removed both flags so release-please applies standard SemVer for post-1.0 packages.

## Test plan

- [x] `release-please-config.json` is still valid JSON
- [ ] Next release-please run produces the expected version bump for queued conventional commits