### PR TITLE
ci: remove auto-publish to nuget on every main push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,10 +51,6 @@ jobs:
               -p:PackageVersion=${{ steps.gitversion.outputs.version }} -o ./artifacts
           done
 
-      - name: Push to NuGet (pre-release)
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        run: dotnet nuget push ./artifacts/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
-
   aot-smoke:
     runs-on: ubuntu-latest
     # Publishes samples/ZeroAlloc.Scheduling.AotSmoke with PublishAot=true.


### PR DESCRIPTION
## Summary
- Removes the `Push to NuGet (pre-release)` step from `.github/workflows/ci.yml` that pushed packages on every main push.
- Per org-wide decision: only release-please-shepherded releases should publish to NuGet.
- Build, test, and pack steps remain unchanged.

## Rationale
The auto-publish step was pushing every sibling package on every main commit, outside release-please's bookkeeping. This conflicts with the org-wide policy that only release-please releases publish to NuGet.

## Test plan
- [ ] CI runs build/test/pack as before
- [ ] No `dotnet nuget push` runs on main pushes
- [ ] release-please flow continues to be the sole publisher