### PR TITLE
ci(release-please): use RELEASE_PLEASE_TOKEN to trigger downstream CI

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: googleapis/release-please-action@v5
         id: release
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
 
   publish:
     needs: release-please


### PR DESCRIPTION
Replaces `GITHUB_TOKEN` with org PAT secret `RELEASE_PLEASE_TOKEN` so release-please PRs trigger the `build` workflow (GITHUB_TOKEN-created PRs/pushes don't trigger workflows by design, which leaves release PRs blocked by the required `build` status check).