### PR TITLE
fix(readme): absolute GitHub URLs so nuget.org links resolve

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,11 +71,11 @@ app.MapJobsDashboard("/jobs");
 app.MapJobsDashboard("/jobs").RequireAuthorization("AdminPolicy");
 ```
 
-![Scheduler dashboard — desktop](docs/screenshots/dashboard-desktop.png)
+![Scheduler dashboard — desktop](https://raw.githubusercontent.com/ZeroAlloc-Net/ZeroAlloc.Scheduling/main/docs/screenshots/dashboard-desktop.png)
 
-Tablet (768 × 1024) and mobile (375 × 812) captures live in [`docs/screenshots/`](docs/screenshots/).
+Tablet (768 × 1024) and mobile (375 × 812) captures live in [`docs/screenshots/`](https://github.com/ZeroAlloc-Net/ZeroAlloc.Scheduling/tree/main/docs/screenshots/).
 
-See [Dashboard](docs/dashboard.md) for the full endpoint reference and the Blazor component.
+See [Dashboard](https://github.com/ZeroAlloc-Net/ZeroAlloc.Scheduling/blob/main/docs/dashboard.md) for the full endpoint reference and the Blazor component.
 
 ## Packages
 
@@ -94,13 +94,13 @@ See [Dashboard](docs/dashboard.md) for the full endpoint reference and the Blazo
 
 | Page | Description |
 |------|-------------|
-| [Getting Started](docs/getting-started.md) | Install and schedule your first job in five minutes |
-| [Source Generator](docs/source-generator.md) | `[Job]`, `Every`, `Cron`, generated extension methods |
-| [Backends](docs/stores.md) | InMemory, EF Core, and Redis store configuration |
-| [Dashboard](docs/dashboard.md) | Embedded HTML dashboard and Blazor component |
-| [Mediator Bridge](docs/mediator-bridge.md) | Route job execution through ZeroAlloc.Mediator |
-| [Diagnostics](docs/diagnostics.md) | ZASCH001 compiler warning reference |
-| [Performance](docs/performance.md) | Throughput, allocation profile, and tuning guide |
+| [Getting Started](https://github.com/ZeroAlloc-Net/ZeroAlloc.Scheduling/blob/main/docs/getting-started.md) | Install and schedule your first job in five minutes |
+| [Source Generator](https://github.com/ZeroAlloc-Net/ZeroAlloc.Scheduling/blob/main/docs/source-generator.md) | `[Job]`, `Every`, `Cron`, generated extension methods |
+| [Backends](https://github.com/ZeroAlloc-Net/ZeroAlloc.Scheduling/blob/main/docs/stores.md) | InMemory, EF Core, and Redis store configuration |
+| [Dashboard](https://github.com/ZeroAlloc-Net/ZeroAlloc.Scheduling/blob/main/docs/dashboard.md) | Embedded HTML dashboard and Blazor component |
+| [Mediator Bridge](https://github.com/ZeroAlloc-Net/ZeroAlloc.Scheduling/blob/main/docs/mediator-bridge.md) | Route job execution through ZeroAlloc.Mediator |
+| [Diagnostics](https://github.com/ZeroAlloc-Net/ZeroAlloc.Scheduling/blob/main/docs/diagnostics.md) | ZASCH001 compiler warning reference |
+| [Performance](https://github.com/ZeroAlloc-Net/ZeroAlloc.Scheduling/blob/main/docs/performance.md) | Throughput, allocation profile, and tuning guide |
 
 ## License
 


### PR DESCRIPTION
## Summary

Rewrite all relative links in `README.md` to absolute GitHub URLs. The README ships to nuget.org via `<PackageReadmeFile>`; nuget.org renders it in its own host context, so any `[text](docs/foo.md)` style links 404 on the package page today.

## Pattern

- File links: `[text](path)` -> `[text](https://github.com/ZeroAlloc-Net/<repo>/blob/main/path)`
- Directory links: `[text](path/)` -> `[text](https://github.com/ZeroAlloc-Net/<repo>/tree/main/path/)`
- Image links: `![alt](img.png)` -> `![alt](https://raw.githubusercontent.com/ZeroAlloc-Net/<repo>/main/img.png)` (raw host so the image renders inline)
- Anchors (`#section`) and already-absolute URLs (`https://...`) unchanged
- `#anchor` fragments preserved on rewritten file links

## Verification

`README.md` still renders cleanly on the GitHub repo page (absolute self-references work in GitHub's renderer too). Once merged, the next NuGet release publishes the updated README and nuget.org links will resolve to the actual files.

Generated with [Claude Code](https://claude.com/claude-code)
